### PR TITLE
Rename various header_map iterator types.

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -84,8 +84,9 @@ pub use self::map::{
     Entry,
     VacantEntry,
     OccupiedEntry,
-    EntryIter,
-    DrainEntry,
+    ValueIter,
+    ValueIterMut,
+    ValueDrain,
     HeaderMapKey,
 };
 pub use self::name::{


### PR DESCRIPTION
`Entry` is better used to represent (key, value) pairs. Instead, use `Value` prefix to name iterators that work on a set of values associated with a key.