### PR TITLE
change Request::version() to return Version by value

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -112,17 +112,17 @@ impl<T> Request<T> {
         &mut self.head.uri
     }
 
-    /// Returns a reference to the associated version.
+    /// Returns the associated version.
     ///
     /// # Examples
     ///
     /// ```
     /// # use http::*;
     /// let request: Request<()> = Request::default();
-    /// assert_eq!(*request.version(), version::HTTP_11);
+    /// assert_eq!(request.version(), version::HTTP_11);
     /// ```
-    pub fn version(&self) -> &Version {
-        &self.head.version
+    pub fn version(&self) -> Version {
+        self.head.version
     }
 
     /// Returns a mutable reference to the associated version.
@@ -133,7 +133,7 @@ impl<T> Request<T> {
     /// # use http::*;
     /// let mut request: Request<()> = Request::default();
     /// *request.version_mut() = version::HTTP_2;
-    /// assert_eq!(*request.version(), version::HTTP_2);
+    /// assert_eq!(request.version(), version::HTTP_2);
     /// ```
     pub fn version_mut(&mut self) -> &mut Version {
         &mut self.head.version


### PR DESCRIPTION
The `Version` should be 1 byte, and it's `Copy`, so it's cheaper to return it by value than to return a pointer.

Additionally, in libstd, the pattern is to return `Copy` fields by value instead of by reference ([SocketAddr example](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html#method.ip))