### PR TITLE
Uri reform

### DIFF
--- a/src/byte_str.rs
+++ b/src/byte_str.rs
@@ -47,3 +47,9 @@ impl<'a> From<&'a str> for ByteStr {
         ByteStr { bytes: Bytes::from(src) }
     }
 }
+
+impl From<ByteStr> for Bytes {
+    fn from(src: ByteStr) -> Self {
+        src.bytes
+    }
+}

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -711,6 +711,20 @@ impl FromStr for Scheme {
     }
 }
 
+impl From<Scheme> for Bytes {
+    fn from(src: Scheme) -> Self {
+        use self::Scheme2::*;
+        use self::Protocol::*;
+
+        match src.inner {
+            None => Bytes::new(),
+            Standard(Http) => Bytes::from_static(b"http"),
+            Standard(Https) => Bytes::from_static(b"https"),
+            Other(v) => (*v).into(),
+        }
+    }
+}
+
 impl<T> Scheme2<T> {
     fn is_none(&self) -> bool {
         match *self {
@@ -906,6 +920,12 @@ impl FromStr for Authority {
     }
 }
 
+impl From<Authority> for Bytes {
+    fn from(src: Authority) -> Bytes {
+        src.data.into()
+    }
+}
+
 impl OriginForm {
     /// Attempt to convert a `OriginForm` from `Bytes`.
     ///
@@ -1065,6 +1085,12 @@ impl FromStr for OriginForm {
 
     fn from_str(s: &str) -> Result<Self, FromStrError> {
         OriginForm::try_from_shared(s.into())
+    }
+}
+
+impl From<OriginForm> for Bytes {
+    fn from(src: OriginForm) -> Bytes {
+        src.data.into()
     }
 }
 


### PR DESCRIPTION
The original implementation of Uri was heavily geared towards HTTP 1 and not super great for H2. This PR attempts to strike a better balance.

The main difference between H1 & H2 URIs is that, in the case of H1, the URI arrives already formatted as a URI and in a single, contiguous, buffer. However, in the case of H2, the various components of the URI are split up into separate pseudo headers and will arrive in disjoint buffers.

This PR splits up the internal representation of the URI into the various components (scheme, authority, and path) allowing for efficient construction from both H1 & H2.

This PR also exposes types from `bytes`, but does so in a limited and non-critical way. I believe the way it is exposed does not provide any future compatibility hazard.

Uri now provides into & from parts, where `Parts`:

```rust
pub struct Parts {
    pub scheme: Option<Scheme>,
    pub authority: Option<Authority>,
    pub origin_form: Option<OriginForm>,
    _priv: (),
}
```

Where `Scheme`, `Authority`, and `OriginForm` all have `try_from_shared(src: Bytes)` function.

The library doesn't provide any guarantee that it is zero copy, only that it will do the best that it can given the provided input. This API is also not at all core to the http API and doesn't block any future evolution of the internals of Uri. However, it does provide efficient conversions right now from H2 and `Uri::try_from_shared` provides an efficient conversion from H1 (if using Bytes).