### PR TITLE
Add owned variants for each error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,8 +26,11 @@ enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),
     Uri(uri::InvalidUri),
+    UriShared(uri::InvalidUriBytes),
     HeaderName(header::InvalidHeaderName),
+    HeaderNameShared(header::InvalidHeaderNameBytes),
     HeaderValue(header::InvalidHeaderValue),
+    HeaderValueShared(header::InvalidHeaderValueBytes),
 }
 
 impl fmt::Display for Error {
@@ -44,8 +47,11 @@ impl error::Error for Error {
             StatusCode(ref e) => e.description(),
             Method(ref e) => e.description(),
             Uri(ref e) => e.description(),
+            UriShared(ref e) => e.description(),
             HeaderName(ref e) => e.description(),
+            HeaderNameShared(ref e) => e.description(),
             HeaderValue(ref e) => e.description(),
+            HeaderValueShared(ref e) => e.description(),
         }
     }
 }
@@ -68,14 +74,32 @@ impl From<uri::InvalidUri> for Error {
     }
 }
 
+impl From<uri::InvalidUriBytes> for Error {
+    fn from(err: uri::InvalidUriBytes) -> Error {
+        Error { inner: ErrorKind::UriShared(err) }
+    }
+}
+
 impl From<header::InvalidHeaderName> for Error {
     fn from(err: header::InvalidHeaderName) -> Error {
         Error { inner: ErrorKind::HeaderName(err) }
     }
 }
 
+impl From<header::InvalidHeaderNameBytes> for Error {
+    fn from(err: header::InvalidHeaderNameBytes) -> Error {
+        Error { inner: ErrorKind::HeaderNameShared(err) }
+    }
+}
+
 impl From<header::InvalidHeaderValue> for Error {
     fn from(err: header::InvalidHeaderValue) -> Error {
         Error { inner: ErrorKind::HeaderValue(err) }
+    }
+}
+
+impl From<header::InvalidHeaderValueBytes> for Error {
+    fn from(err: header::InvalidHeaderValueBytes) -> Error {
+        Error { inner: ErrorKind::HeaderValueShared(err) }
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -93,10 +93,12 @@ pub use self::map::{
 pub use self::name::{
     HeaderName,
     InvalidHeaderName,
+    InvalidHeaderNameBytes,
 };
 pub use self::value::{
     HeaderValue,
     InvalidHeaderValue,
+    InvalidHeaderValueBytes,
     ToStrError,
 };
 

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -61,6 +61,10 @@ pub struct InvalidHeaderName {
     _priv: (),
 }
 
+/// A possible error when converting a `HeaderName` from another type.
+#[derive(Debug)]
+pub struct InvalidHeaderNameBytes(InvalidHeaderName) ;
+
 macro_rules! standard_headers {
     (
         $(
@@ -1558,10 +1562,10 @@ impl<'a> HttpTryFrom<&'a [u8]> for HeaderName {
 }
 
 impl HttpTryFrom<Bytes> for HeaderName {
-    type Error = InvalidHeaderName;
+    type Error = InvalidHeaderNameBytes;
     #[inline]
     fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        Self::from_bytes(bytes.as_ref())
+        Self::from_bytes(bytes.as_ref()).map_err(InvalidHeaderNameBytes)
     }
 }
 
@@ -1625,6 +1629,18 @@ impl fmt::Display for InvalidHeaderName {
 impl Error for InvalidHeaderName {
     fn description(&self) -> &str {
         "invalid HTTP header name"
+    }
+}
+
+impl fmt::Display for InvalidHeaderNameBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for InvalidHeaderNameBytes {
+    fn description(&self) -> &str {
+        self.0.description()
     }
 }
 


### PR DESCRIPTION
For all fallible functions that consume `Bytes` a new `InvalidFooShared` error
has been added. Eventually this extra error type can retain the input `Bytes`
payload to be re-acquired on error if necessary.

Closes #48