### PR TITLE
feat(*): make all errors cloneable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use uri;
 /// functions in this crate, but all other errors can be converted to this
 /// error. Consumers of this crate can typically consume and work with this form
 /// of error for conversions with the `?` operator.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Error {
     inner: ErrorKind,
 }
@@ -21,7 +21,7 @@ pub struct Error {
 /// A `Result` typedef to use with the `http::Error` type
 pub type Result<T> = result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -56,13 +56,13 @@ struct MaybeLower<'a> {
 }
 
 /// A possible error when converting a `HeaderName` from another type.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidHeaderName {
     _priv: (),
 }
 
 /// A possible error when converting a `HeaderName` from another type.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidHeaderNameBytes(InvalidHeaderName) ;
 
 macro_rules! standard_headers {

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -23,21 +23,21 @@ pub struct HeaderValue {
 
 /// A possible error when converting a `HeaderValue` from a string or byte
 /// slice.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidHeaderValue {
     _priv: (),
 }
 
 /// A possible error when converting a `HeaderValue` from a string or byte
 /// slice.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidHeaderValueBytes(InvalidHeaderValue);
 
 /// A possible error when converting a `HeaderValue` to a string representation.
 ///
 /// Header field values may contain opaque bytes, in which case it is not
 /// possible to represent the value as a string.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ToStrError {
     _priv: (),
 }

--- a/src/method.rs
+++ b/src/method.rs
@@ -44,7 +44,7 @@ use std::error::Error;
 pub struct Method(Inner);
 
 /// A possible error value when converting `Method` from bytes.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidMethod {
     _priv: (),
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -51,7 +51,7 @@ pub struct StatusCode(u16);
 ///
 /// This error indicates that the supplied input was not a valid number, was less
 /// than 100, or was greater than 599.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidStatusCode {
     _priv: (),
 }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -135,18 +135,18 @@ pub struct Parts {
 }
 
 /// An error resulting from a failed attempt to construct a URI.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidUri(ErrorKind);
 
 /// An error resulting from a failed attempt to construct a URI.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidUriBytes(InvalidUri);
 
 /// An error resulting from a failed attempt to construct a URI.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidUriParts(InvalidUri);
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum ErrorKind {
     InvalidUriChar,
     InvalidScheme,


### PR DESCRIPTION
When working on implementing compatibility with the `http` crate over in `hyper`, I ran into a problem where the error types in `http` are not `Clone`. This PR changes that.

I guess this locks in the error API quite a bit (errors can't contain any non-cloneable information), but  on the other hand it also makes it possible for `hyper` to leverage logic from `http` more easily.

Let me know if you like this or if I should try to make do with non-cloneable errors.