### PR TITLE
Provide Uri accessor for Authority.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! `Method` and `headers` to inspect the various headers. A `Response`
 //! has similar methods for headers, the status code, etc.
 //!
-//! In addition to getters, request/response types also have mutable accessors 
+//! In addition to getters, request/response types also have mutable accessors
 //! to edit the request/response:
 //!
 //! ```

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1133,8 +1133,9 @@ impl PartialEq<str> for Authority {
 /// ```
 impl Hash for Authority {
     fn hash<H>(&self, state: &mut H) where H: Hasher {
-        self.data.as_bytes()
-            .to_ascii_lowercase().hash(state);
+        for &b in self.data.as_bytes() {
+            state.write_u8(b.to_ascii_lowercase());
+        }
     }
 }
 


### PR DESCRIPTION
Currently, there is no way to access the `Authority` component of `Uri`
at a type level. This is desireable because:

* `Authority` is backed by `Bytes` (for clone).
* `Authority` should be case-insensitive for Eq / Hash.

Unfortunately, `Uri::authority` already exists and returns a `&str`.
This is an oversight that originated from the original iteration of
`Uri` not providing typed components.

This PR adds an `authority_part` accessor to URI and deprecates
`authority` with the expectation that the next semver release of `http`
will rename `authority_part` back to `authority`.

This PR also provides an `Eq` and `Hash` implementation for `Authority`
and adds `Authority::port`.