### PR TITLE
Fix license text

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ fn main() {
 
 # License
 
-`http` is primarily distributed under the terms of both the MIT license and the
-Apache License (Version 2.0), with portions covered by various BSD-like
-licenses.
+Licensed under either of
 
-See LICENSE-APACHE, and LICENSE-MIT for details.
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
The intent of the license text is to dual license under MIT / Apache 2.0. This PR clarifies the text.