### PR TITLE
Implement PartialOrd/PartialEq for Authority and PathAndQuery

### DIFF
--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -1,6 +1,6 @@
 #[allow(unused)]
 use std::ascii::AsciiExt;
-use std::fmt;
+use std::{cmp, fmt, str};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
@@ -192,6 +192,64 @@ impl PartialEq<str> for Authority {
     }
 }
 
+impl PartialEq<Authority> for str {
+    fn eq(&self, other: &Authority) -> bool {
+        self.eq_ignore_ascii_case(other.as_str())
+    }
+}
+
+impl PartialEq<String> for Authority {
+    fn eq(&self, other: &String) -> bool {
+        self.data.eq_ignore_ascii_case(other.as_str())
+    }
+}
+
+impl PartialEq<Authority> for String {
+    fn eq(&self, other: &Authority) -> bool {
+        self.as_str().eq_ignore_ascii_case(other.as_str())
+    }
+}
+
+/// Case-insensitive ordering
+///
+/// # Examples
+///
+/// ```
+/// # use http::uri::Authority;
+/// let authority: Authority = "DEF.com".parse().unwrap();
+/// assert!(authority < *"ghi.com");
+/// assert!(authority > *"abc.com");
+/// ```
+impl PartialOrd for Authority {
+    fn partial_cmp(&self, other: &Authority) -> Option<cmp::Ordering> {
+        self.data.to_ascii_lowercase().partial_cmp(&other.data.to_ascii_lowercase())
+    }
+}
+
+impl PartialOrd<str> for Authority {
+    fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
+        self.data.to_ascii_lowercase().partial_cmp(&other.to_ascii_lowercase())
+    }
+}
+
+impl PartialOrd<Authority> for str {
+    fn partial_cmp(&self, other: &Authority) -> Option<cmp::Ordering> {
+        self.to_ascii_lowercase().partial_cmp(&other.as_str().to_ascii_lowercase())
+    }
+}
+
+impl PartialOrd<String> for Authority {
+    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+        self.data.to_ascii_lowercase().partial_cmp(&other.as_str().to_ascii_lowercase())
+    }
+}
+
+impl PartialOrd<Authority> for String {
+    fn partial_cmp(&self, other: &Authority) -> Option<cmp::Ordering> {
+        self.as_str().to_ascii_lowercase().partial_cmp(&other.data.to_ascii_lowercase())
+    }
+}
+
 /// Case-insensitive hashing
 ///
 /// # Examples
@@ -268,5 +326,80 @@ fn host(auth: &str) -> &str {
         host_port.split(':')
             .next()
             .expect("split always has at least 1 item")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_to_self_of_same_authority() {
+        let authority1: Authority = "example.com".parse().unwrap();
+        let authority2: Authority = "EXAMPLE.COM".parse().unwrap();
+        assert_eq!(authority1, authority2);
+        assert_eq!(authority2, authority1);
+    }
+
+    #[test]
+    fn not_equal_to_self_of_different_authority() {
+        let authority1: Authority = "example.com".parse().unwrap();
+        let authority2: Authority = "test.com".parse().unwrap();
+        assert_ne!(authority1, authority2);
+        assert_ne!(authority2, authority1);
+    }
+
+    #[test]
+    fn equates_with_a_str() {
+        let authority: Authority = "example.com".parse().unwrap();
+        assert_eq!(&authority, "EXAMPLE.com");
+        assert_eq!("EXAMPLE.com", &authority);
+    }
+
+    #[test]
+    fn not_equal_with_a_str_of_a_different_authority() {
+        let authority: Authority = "example.com".parse().unwrap();
+        assert_ne!(&authority, "test.com");
+        assert_ne!("test.com", &authority);
+    }
+
+    #[test]
+    fn equates_with_a_string() {
+        let authority: Authority = "example.com".parse().unwrap();
+        assert_eq!(authority, "EXAMPLE.com".to_string());
+        assert_eq!("EXAMPLE.com".to_string(), authority);
+    }
+
+    #[test]
+    fn equates_with_a_string_of_a_different_authority() {
+        let authority: Authority = "example.com".parse().unwrap();
+        assert_ne!(authority, "test.com".to_string());
+        assert_ne!("test.com".to_string(), authority);
+    }
+
+    #[test]
+    fn compares_to_self() {
+        let authority1: Authority = "abc.com".parse().unwrap();
+        let authority2: Authority = "def.com".parse().unwrap();
+        assert!(authority1 < authority2);
+        assert!(authority2 > authority1);
+    }
+
+    #[test]
+    fn compares_with_a_str() {
+        let authority: Authority = "def.com".parse().unwrap();
+        assert!(&authority < "ghi.com");
+        assert!("ghi.com" > &authority);
+        assert!(&authority > "abc.com");
+        assert!("abc.com" < &authority);
+    }
+
+    #[test]
+    fn compares_with_a_string() {
+        let authority: Authority = "def.com".parse().unwrap();
+        assert!(authority < "ghi.com".to_string());
+        assert!("ghi.com".to_string() > authority);
+        assert!(authority > "abc.com".to_string());
+        assert!("abc.com".to_string() < authority);
     }
 }

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{cmp, fmt, str};
 use std::str::FromStr;
 
 use bytes::Bytes;
@@ -286,6 +286,80 @@ impl fmt::Display for PathAndQuery {
     }
 }
 
+// ===== PartialEq / PartialOrd =====
+
+impl PartialEq for PathAndQuery {
+    #[inline]
+    fn eq(&self, other: &PathAndQuery) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for PathAndQuery {}
+
+impl PartialEq<str> for PathAndQuery {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<PathAndQuery> for str {
+    #[inline]
+    fn eq(&self, other: &PathAndQuery) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<String> for PathAndQuery {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<PathAndQuery> for String {
+    #[inline]
+    fn eq(&self, other: &PathAndQuery) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialOrd for PathAndQuery {
+    #[inline]
+    fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl PartialOrd<str> for PathAndQuery {
+    #[inline]
+    fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other)
+    }
+}
+
+impl PartialOrd<PathAndQuery> for str {
+    #[inline]
+    fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
+        self.partial_cmp(other.as_str())
+    }
+}
+
+impl PartialOrd<String> for PathAndQuery {
+    #[inline]
+    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl PartialOrd<PathAndQuery> for String {
+    #[inline]
+    fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
 const HEX_DIGIT: [u8; 256] = [
     //  0      1      2      3      4      5      6      7      8      9
         0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //   x
@@ -315,3 +389,78 @@ const HEX_DIGIT: [u8; 256] = [
         0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 24x
         0,     0,     0,     0,     0,     0                              // 25x
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_to_self_of_same_path() {
+        let p1: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        let p2: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        assert_eq!(p1, p2);
+        assert_eq!(p2, p1);
+    }
+
+    #[test]
+    fn not_equal_to_self_of_different_path() {
+        let p1: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        let p2: PathAndQuery = "/world&foo=bar".parse().unwrap();
+        assert_ne!(p1, p2);
+        assert_ne!(p2, p1);
+    }
+
+    #[test]
+    fn equates_with_a_str() {
+        let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        assert_eq!(&path_and_query, "/hello/world&foo=bar");
+        assert_eq!("/hello/world&foo=bar", &path_and_query);
+    }
+
+    #[test]
+    fn not_equal_with_a_str_of_a_different_path() {
+        let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        assert_ne!(&path_and_query, "/hello&foo=bar");
+        assert_ne!("/hello&foo=bar", &path_and_query);
+    }
+
+    #[test]
+    fn equates_with_a_string() {
+        let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        assert_eq!(path_and_query, "/hello/world&foo=bar".to_string());
+        assert_eq!("/hello/world&foo=bar".to_string(), path_and_query);
+    }
+
+    #[test]
+    fn not_equal_with_a_string_of_a_different_path() {
+        let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        assert_ne!(path_and_query, "/hello&foo=bar".to_string());
+        assert_ne!("/hello&foo=bar".to_string(), path_and_query);
+    }
+
+    #[test]
+    fn compares_to_self() {
+        let p1: PathAndQuery = "/a/world&foo=bar".parse().unwrap();
+        let p2: PathAndQuery = "/b/world&foo=bar".parse().unwrap();
+        assert!(p1 < p2);
+        assert!(p2 > p1);
+    }
+
+    #[test]
+    fn compares_with_a_str() {
+        let path_and_query: PathAndQuery = "/b/world&foo=bar".parse().unwrap();
+        assert!(&path_and_query < "/c/world&foo=bar");
+        assert!("/c/world&foo=bar" > &path_and_query);
+        assert!(&path_and_query > "/a/world&foo=bar");
+        assert!("/a/world&foo=bar" < &path_and_query);
+    }
+
+    #[test]
+    fn compares_with_a_string() {
+        let path_and_query: PathAndQuery = "/b/world&foo=bar".parse().unwrap();
+        assert!(path_and_query < "/c/world&foo=bar".to_string());
+        assert!("/c/world&foo=bar".to_string() > path_and_query);
+        assert!(path_and_query > "/a/world&foo=bar".to_string());
+        assert!("/a/world&foo=bar".to_string() < path_and_query);
+    }
+}

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -291,7 +291,7 @@ impl fmt::Display for PathAndQuery {
 impl PartialEq for PathAndQuery {
     #[inline]
     fn eq(&self, other: &PathAndQuery) -> bool {
-        self.as_str() == other.as_str()
+        self.data == other.data
     }
 }
 
@@ -301,6 +301,20 @@ impl PartialEq<str> for PathAndQuery {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
+    }
+}
+
+impl<'a> PartialEq<PathAndQuery> for &'a str {
+    #[inline]
+    fn eq(&self, other: &PathAndQuery) -> bool {
+        self == &other.as_str()
+    }
+}
+
+impl<'a> PartialEq<&'a str> for PathAndQuery {
+    #[inline]
+    fn eq(&self, other: &&'a str) -> bool {
+        self.as_str() == *other
     }
 }
 
@@ -343,6 +357,20 @@ impl PartialOrd<PathAndQuery> for str {
     #[inline]
     fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
         self.partial_cmp(other.as_str())
+    }
+}
+
+impl<'a> PartialOrd<&'a str> for PathAndQuery {
+    #[inline]
+    fn partial_cmp(&self, other: &&'a str) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(*other)
+    }
+}
+
+impl<'a> PartialOrd<PathAndQuery> for &'a str {
+    #[inline]
+    fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
+        self.partial_cmp(&other.as_str())
     }
 }
 
@@ -415,13 +443,19 @@ mod tests {
         let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
         assert_eq!(&path_and_query, "/hello/world&foo=bar");
         assert_eq!("/hello/world&foo=bar", &path_and_query);
+        assert_eq!(path_and_query, "/hello/world&foo=bar");
+        assert_eq!("/hello/world&foo=bar", path_and_query);
     }
 
     #[test]
     fn not_equal_with_a_str_of_a_different_path() {
         let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
+        // as a reference
         assert_ne!(&path_and_query, "/hello&foo=bar");
         assert_ne!("/hello&foo=bar", &path_and_query);
+        // without reference
+        assert_ne!(path_and_query, "/hello&foo=bar");
+        assert_ne!("/hello&foo=bar", path_and_query);
     }
 
     #[test]
@@ -449,10 +483,17 @@ mod tests {
     #[test]
     fn compares_with_a_str() {
         let path_and_query: PathAndQuery = "/b/world&foo=bar".parse().unwrap();
+        // by ref
         assert!(&path_and_query < "/c/world&foo=bar");
         assert!("/c/world&foo=bar" > &path_and_query);
         assert!(&path_and_query > "/a/world&foo=bar");
         assert!("/a/world&foo=bar" < &path_and_query);
+
+        // by val
+        assert!(path_and_query < "/c/world&foo=bar");
+        assert!("/c/world&foo=bar" > path_and_query);
+        assert!(path_and_query > "/a/world&foo=bar");
+        assert!("/a/world&foo=bar" < path_and_query);
     }
 
     #[test]

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -216,6 +216,36 @@ impl PathAndQuery {
         }
     }
 
+    /// Returns the path and query as a string component.
+    ///
+    /// # Examples
+    ///
+    /// With a query string component
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let path_and_query: PathAndQuery = "/hello/world?key=value&foo=bar".parse().unwrap();
+    ///
+    /// assert_eq!(path_and_query.as_str(), "/hello/world?key=value&foo=bar");
+    /// ```
+    ///
+    /// Without a query string component
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let path_and_query: PathAndQuery = "/hello/world".parse().unwrap();
+    ///
+    /// assert_eq!(path_and_query.as_str(), "/hello/world");
+    /// ```
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        let ret = &self.data[..];
+        if ret.is_empty() {
+            return "/";
+        }
+        ret
+    }
+
     /// Converts this `PathAndQuery` back to a sequence of bytes
     #[inline]
     pub fn into_bytes(self) -> Bytes {


### PR DESCRIPTION
Implementation of PartialOrd and PartialEq for Authority and PathAndQuery. Implementations are bidirectional and units tests are added for all. Authority has been implemented with case-insensitivity in mind.

cc: @carllerche 

closes #149 