### PR TITLE
Implements PartielEq for StatusCode with u16

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -170,6 +170,20 @@ impl Default for StatusCode {
     }
 }
 
+impl PartialEq<u16> for StatusCode {
+    #[inline]
+    fn eq(&self, other: &u16) -> bool {
+        self.as_u16() == *other
+    }
+}
+
+impl PartialEq<StatusCode> for u16 {
+    #[inline]
+    fn eq(&self, other: &StatusCode) -> bool {
+        *self == other.as_u16()
+    }
+}
+
 impl From<StatusCode> for u16 {
     #[inline]
     fn from(status: StatusCode) -> u16 {

--- a/tests/status_code.rs
+++ b/tests/status_code.rs
@@ -13,6 +13,13 @@ fn from_bytes() {
     }
 }
 
+#[test]
+fn equates_with_u16() {
+    let status = StatusCode::from_u16(200u16).unwrap();
+    assert_eq!(200u16, status);
+    assert_eq!(status, 200u16);
+}
+
 macro_rules! test_round_trip {
     ($($num:expr,)+) => {
         #[test]


### PR DESCRIPTION
As a convenience, it's shorter to write:

`status == 400`

rather than:

`status.as_u16() == 400`
or
`status == StatusCode(400)`

I was writing tests for builder convenience methods with status and realized that it might be simpler to be able to compare a status code directly with a u16 rather than needing to call a method. So I inlined the implementations of eq.

closes #152 
  