### PR TITLE
Implement HttpTryFrom<&Uri> for Uri.

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -618,6 +618,15 @@ impl HttpTryFrom<Parts> for Uri {
     }
 }
 
+impl<'a> HttpTryFrom<&'a Uri> for Uri {
+    type Error = ::Error;
+
+    #[inline]
+    fn try_from(src: &'a Uri) -> Result<Self, Self::Error> {
+        Ok(src.clone())
+    }
+}
+
 /// Convert a `Uri` from parts
 ///
 /// # Examples


### PR DESCRIPTION
Since Uri is `Clone`, the conversion is infallible. However, it is still
useful to have as HttpTryFrom is used as the main trait when building
various types.