### PR TITLE
request & response: add into_body methods

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -624,6 +624,22 @@ impl<T> Request<T> {
         &mut self.body
     }
 
+
+    /// Consumes the request, returning just the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::Request;
+    /// let request = Request::new(10);
+    /// let body = request.into_body();
+    /// assert_eq!(body, 10);
+    /// ```
+    #[inline]
+    pub fn into_body(self) -> T {
+        self.body
+    }
+
     /// Consumes the request returning the head and body parts.
     ///
     /// # Examples

--- a/src/response.rs
+++ b/src/response.rs
@@ -425,6 +425,21 @@ impl<T> Response<T> {
         &mut self.body
     }
 
+    /// Consumes the response, returning just the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::Response;
+    /// let response = Response::new(10);
+    /// let body = response.into_body();
+    /// assert_eq!(body, 10);
+    /// ```
+    #[inline]
+    pub fn into_body(self) -> T {
+        self.body
+    }
+
     /// Consumes the response returning the head and body parts.
     ///
     /// # Examples


### PR DESCRIPTION
It's messy to have to write `res.into_parts().1.concat()`. This allows writing `res.into_body().concat()`.