### PR TITLE
Fix Request::options()

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -311,11 +311,12 @@ impl Request<()> {
     /// let request = Request::options("https://www.rust-lang.org/")
     ///     .body(())
     ///     .unwrap();
+    /// # assert_eq!(*request.method(), Method::OPTIONS);
     /// ```
     pub fn options<T>(uri: T) -> Builder
         where Uri: HttpTryFrom<T> {
         let mut b = Builder::new();
-        b.method(Method::DELETE).uri(uri);
+        b.method(Method::OPTIONS).uri(uri);
         b
     }
 


### PR DESCRIPTION
This function currently returns a builder set to the DELETE method, most
likely due to a copy / paste related bug.

This patch fixes the builder such that it is correctly set to use the
OPTIONS method.