### PR TITLE
Implement Clone for header::ToStrError

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -38,7 +38,7 @@ pub struct InvalidHeaderValueBytes(InvalidHeaderValue);
 ///
 /// Header field values may contain opaque bytes, in which case it is not
 /// possible to represent the value as a string.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ToStrError {
     _priv: (),
 }


### PR DESCRIPTION
Hello,

Thank you for the great library!

I faced with the problem where I need `header::ToStrError` to implement `Clone` trait.
Let me describe my use case.

I am working on web service with actix-web (as transport) and jsonrpc-core (as business logic).
I need to implement authentication via JWT.
So, at transport layer I fetch `Authorization` header and convert it to `Result<String, ToStrError>` if it is present. You can see it [here](https://github.com/netology-group/iam/pull/15/files#diff-b4aea3e418ccdb71239b96952d9cddb6R79).
In order to pass it to business logic layer I need to use jsonrpc-core [`Metadata`](https://docs.rs/jsonrpc-core/8.0.1/jsonrpc_core/trait.Metadata.html) feature.
I defined my metadata as [the following](https://github.com/netology-group/iam/pull/15/files#diff-c4f869d1c823b426c320d58fb8cab701R28).
And because of `Metadata: Clone` it requires `header::ToStrError: Clone`.

There are few reasons for passing `Option<Result<String, actix_web::http::header::ToStrError>>` via metadata and not just `String`:
- It allows me to have a single point for checking token presence and signature.
- According to JSON-RPC specification I need to provide corresponding `id` on `Unauthorized` responses. For that I need to parse request first and get `id`s from there. There are different kinds of requests: single, batch, method call, notification.

Maybe this code could be written in another way, i.e. moving authentication middleware to actix-web side. But I think current approach where actix-web is only acting as transport layer is more clear and correct.

So, I thought that we could implement `Clone` for `header::ToStrError`.
I am not sure if doing this has any drawbacks.
Please, tell me what you think about that.

Thank you.