### PR TITLE
Revert "Impl Clone for header::ToStrError (#203)"

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -38,7 +38,7 @@ pub struct InvalidHeaderValueBytes(InvalidHeaderValue);
 ///
 /// Header field values may contain opaque bytes, in which case it is not
 /// possible to represent the value as a string.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ToStrError {
     _priv: (),
 }


### PR DESCRIPTION
Errors explicitly avoid `Clone` in order to be future compatible with
adding inner field types that may not be `Clone`. Many Rust errors do
not impl `Clone`, so adding a `Clone` impl to an error prevents it from
containing other errors in the future.

This reverts commit 46ee6f8b408801385d9c1647dd60529be7d40bc4.