### PR TITLE
Add conversions between Uri and Url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ categories = ["web-programming"]
 [dependencies]
 bytes = "0.4"
 fnv = "1.0.5"
+url = "1.7.0"
 
 [dev-dependencies]
 indexmap = "1.0"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -5,6 +5,8 @@ use sealed::Sealed;
 use status::StatusCode;
 use uri::Uri;
 
+use url::Url;
+
 /// Private trait for the `http` crate to have generic methods with fallible
 /// conversions.
 ///
@@ -38,6 +40,7 @@ macro_rules! reflexive {
 
 reflexive! {
     Uri,
+    Url,
     Method,
     StatusCode,
     HeaderName,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use std::error;
 use std::fmt;
 use std::result;
 
+use url::ParseError;
+
 use header;
 use method;
 use status;
@@ -28,6 +30,7 @@ enum ErrorKind {
     Uri(uri::InvalidUri),
     UriShared(uri::InvalidUriBytes),
     UriParts(uri::InvalidUriParts),
+    Url(ParseError),
     HeaderName(header::InvalidHeaderName),
     HeaderNameShared(header::InvalidHeaderNameBytes),
     HeaderValue(header::InvalidHeaderValue),
@@ -50,6 +53,7 @@ impl error::Error for Error {
             Uri(ref e) => e.description(),
             UriShared(ref e) => e.description(),
             UriParts(ref e) => e.description(),
+            Url(ref e) => e.description(),
             HeaderName(ref e) => e.description(),
             HeaderNameShared(ref e) => e.description(),
             HeaderValue(ref e) => e.description(),
@@ -87,6 +91,13 @@ impl From<uri::InvalidUriParts> for Error {
         Error { inner: ErrorKind::UriParts(err) }
     }
 }
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Error {
+        Error { inner: ErrorKind::Url(err) }
+    }
+}
+
 
 impl From<header::InvalidHeaderName> for Error {
     fn from(err: header::InvalidHeaderName) -> Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@
 
 extern crate bytes;
 extern crate fnv;
+extern crate url;
 
 pub mod header;
 pub mod method;

--- a/src/request.rs
+++ b/src/request.rs
@@ -55,6 +55,8 @@
 use std::any::Any;
 use std::fmt;
 
+use url::Url;
+
 use {Uri, Error, Result, HttpTryFrom, Extensions};
 use header::{HeaderMap, HeaderName, HeaderValue};
 use method::Method;
@@ -504,6 +506,13 @@ impl<T> Request<T> {
     #[inline]
     pub fn uri_mut(&mut self) -> &mut Uri {
         &mut self.head.uri
+    }
+
+    /// Returns the absolute target URL if available.
+    /// 
+    /// Helper function to get the target `Url` for a request.
+    pub fn target(&self) -> Option<Url> {
+       Url::try_from(self.uri()).ok()
     }
 
     /// Returns the associated version.

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -35,6 +35,8 @@ use std::hash::{Hash, Hasher};
 use std::str::{self, FromStr};
 use std::error::Error;
 
+use url::Url;
+
 use self::scheme::Scheme2;
 
 pub use self::authority::Authority;
@@ -643,6 +645,22 @@ impl<'a> HttpTryFrom<&'a Uri> for Uri {
     #[inline]
     fn try_from(src: &'a Uri) -> Result<Self, Self::Error> {
         Ok(src.clone())
+    }
+}
+
+impl<'a> HttpTryFrom<&'a Url> for Uri {
+    type Error = InvalidUri;
+
+    fn try_from(src: &'a Url) -> Result<Self, Self::Error> {
+        Uri::try_from(src.as_str())
+    }
+}
+
+impl<'a> HttpTryFrom<&'a Uri> for Url {
+    type Error = ::url::ParseError;
+
+    fn try_from(src: &'a Uri) -> Result<Self, Self::Error> {
+        Url::parse(src.to_string().as_str())
     }
 }
 

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -387,3 +387,15 @@ fn test_uri_to_path_and_query() {
         assert_eq!(s, case.1);
     }
 }
+
+#[test]
+fn test_convert_uri_url() {
+    use convert::HttpTryFrom;
+
+    let url = ::url::Url::parse("http://example.org/search?q=foobar#page-2").unwrap();
+    let uri = Uri::try_from(&url).unwrap();
+    assert_eq!(uri.scheme_part().map(|v| v.as_str()), Some("http"));
+    assert_eq!(uri.authority_part().map(|v| v.as_str()), Some("example.org"));
+    assert_eq!(uri.path(), "/search");
+    assert_eq!(uri.query(), Some("q=foobar"));
+}


### PR DESCRIPTION
Add Request::target method to get request URL.

The `Uri` is always turned into a string before parsing as a `Url` and vice versa. So this only improves ergonomics but not performance. This can be a later PR.

Open question: The URL crate has a number of dependencies on its own. Should this be an optional feature?

cc @carllerche 