### PR TITLE
fix round trip of authority-form Uri to Parts

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -134,6 +134,7 @@ enum ErrorKind {
     InvalidScheme,
     InvalidAuthority,
     InvalidFormat,
+    SchemeMissing,
     AuthorityMissing,
     PathAndQueryMissing,
     TooLong,
@@ -186,8 +187,8 @@ impl Uri {
                 return Err(ErrorKind::PathAndQueryMissing.into());
             }
         } else {
-            if src.authority.is_some() && src.path_and_query.is_none() {
-                return Err(ErrorKind::PathAndQueryMissing.into());
+            if src.authority.is_some() && src.path_and_query.is_some() {
+                return Err(ErrorKind::SchemeMissing.into());
             }
         }
 
@@ -988,6 +989,7 @@ impl Error for InvalidUri {
             ErrorKind::InvalidScheme => "invalid scheme",
             ErrorKind::InvalidAuthority => "invalid authority",
             ErrorKind::InvalidFormat => "invalid format",
+            ErrorKind::SchemeMissing => "scheme missing",
             ErrorKind::AuthorityMissing => "authority missing",
             ErrorKind::PathAndQueryMissing => "path missing",
             ErrorKind::TooLong => "uri too long",

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -414,3 +414,16 @@ fn test_uri_to_path_and_query() {
         assert_eq!(s, case.1);
     }
 }
+
+#[test]
+fn test_authority_uri_parts_round_trip() {
+    let s = "hyper.rs";
+    let uri = Uri::from_str(s).expect("first parse");
+    assert_eq!(uri, s);
+    assert_eq!(uri.to_string(), s);
+
+    let parts = uri.into_parts();
+    let uri2 = Uri::from_parts(parts).expect("from_parts");
+    assert_eq!(uri2, s);
+    assert_eq!(uri2.to_string(), s);
+}


### PR DESCRIPTION
Before this, you can parse an `authority-form` URI as a `Uri`, but if you convert it into `Parts`, and then try to convert back to `Uri`, it will error.