### PR TITLE
Introduce a Uri Builder

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -3,7 +3,7 @@ use header::{HeaderName, HeaderValue};
 use method::Method;
 use sealed::Sealed;
 use status::StatusCode;
-use uri::Uri;
+use uri::{Scheme, Authority, PathAndQuery, Uri};
 
 /// Private trait for the `http` crate to have generic methods with fallible
 /// conversions.
@@ -20,6 +20,22 @@ pub trait HttpTryFrom<T>: Sized + Sealed {
 
     #[doc(hidden)]
     fn try_from(t: T) -> Result<Self, Self::Error>;
+}
+
+pub(crate) trait HttpTryInto<T>: Sized {
+    fn http_try_into(self) -> Result<T, Error>;
+}
+
+#[doc(hidden)]
+impl<T, U> HttpTryInto<U> for T
+where
+    U: HttpTryFrom<T>,
+    T: Sized,
+{
+    fn http_try_into(self) -> Result<U, Error> {
+        HttpTryFrom::try_from(self)
+            .map_err(|e: U::Error| e.into())
+    }
 }
 
 macro_rules! reflexive {
@@ -42,4 +58,7 @@ reflexive! {
     StatusCode,
     HeaderName,
     HeaderValue,
+    Scheme,
+    Authority,
+    PathAndQuery,
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -725,8 +725,7 @@ impl fmt::Debug for Parts {
 }
 
 impl Builder {
-    /// Creates a new default instance of `Builder` to construct either a
-    /// `Head` or a `Request`.
+    /// Creates a new default instance of `Builder` to construct a `Request`.
     ///
     /// # Examples
     ///

--- a/src/uri/builder.rs
+++ b/src/uri/builder.rs
@@ -1,0 +1,156 @@
+use {Uri, Result};
+use convert::{HttpTryFrom, HttpTryInto};
+use super::{Authority, Scheme, Parts, PathAndQuery};
+
+/// A builder for `Uri`s.
+///
+/// This type can be used to construct an instance of `Uri`
+/// through a builder pattern.
+#[derive(Debug)]
+pub struct Builder {
+    parts: Option<Result<Parts>>,
+}
+
+impl Builder {
+    /// Creates a new default instance of `Builder` to construct a `Uri`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let uri = uri::Builder::new()
+    ///     .scheme("https")
+    ///     .authority("hyper.rs")
+    ///     .path_and_query("/")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    #[inline]
+    pub fn new() -> Builder {
+        Builder::default()
+    }
+
+    /// Set the `Scheme` for this URI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let mut builder = uri::Builder::new();
+    /// builder.scheme("https");
+    /// ```
+    pub fn scheme<T>(&mut self, scheme: T) -> &mut Self
+    where
+        Scheme: HttpTryFrom<T>,
+    {
+        self.map(|parts| {
+            parts.scheme = Some(scheme.http_try_into()?);
+            Ok(())
+        })
+    }
+
+    /// Set the `Authority` for this URI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let uri = uri::Builder::new()
+    ///     .authority("tokio.rs")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn authority<T>(&mut self, auth: T) -> &mut Self
+    where
+        Authority: HttpTryFrom<T>,
+    {
+        self.map(|parts| {
+            parts.authority = Some(auth.http_try_into()?);
+            Ok(())
+        })
+    }
+
+    /// Set the `PathAndQuery` for this URI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let uri = uri::Builder::new()
+    ///     .path_and_query("/hello?foo=bar")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn path_and_query<T>(&mut self, p_and_q: T) -> &mut Self
+    where
+        PathAndQuery: HttpTryFrom<T>,
+    {
+        self.map(|parts| {
+            parts.path_and_query = Some(p_and_q.http_try_into()?);
+            Ok(())
+        })
+    }
+
+    /// Consumes this builder, and tries to construct a valid `Uri` from
+    /// the configured pieces.
+    ///
+    /// # Errors
+    ///
+    /// This function may return an error if any previously configured argument
+    /// failed to parse or get converted to the internal representation. For
+    /// example if an invalid `scheme` was specified via `scheme("!@#%/^")`
+    /// the error will be returned when this function is called rather than
+    /// when `scheme` was called.
+    ///
+    /// Additionally, the various forms of URI require certain combinations of
+    /// parts to be set to be valid. If the parts don't fit into any of the
+    /// valid forms of URI, a new error is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let uri = Uri::builder()
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(&mut self) -> Result<Uri> {
+        self
+            .parts
+            .take()
+            .expect("cannot reuse Uri builder")
+            .and_then(|parts| parts.http_try_into())
+    }
+
+    fn map<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut Parts) -> Result<()>,
+    {
+        let res = if let Some(Ok(ref mut parts)) = self.parts {
+            f(parts)
+        } else {
+            return self;
+        };
+
+        if let Err(err) = res {
+            self.parts = Some(Err(err));
+        }
+
+        self
+    }
+}
+
+impl Default for Builder {
+    #[inline]
+    fn default() -> Builder {
+        Builder {
+            parts: Some(Ok(Parts::default())),
+        }
+    }
+}
+

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -38,11 +38,13 @@ use std::error::Error;
 use self::scheme::Scheme2;
 
 pub use self::authority::Authority;
+pub use self::builder::Builder;
 pub use self::path::PathAndQuery;
 pub use self::scheme::Scheme;
 pub use self::port::Port;
 
 mod authority;
+mod builder;
 mod path;
 mod port;
 mod scheme;
@@ -178,6 +180,27 @@ const URI_CHARS: [u8; 256] = [
 ];
 
 impl Uri {
+    /// Creates a new builder-style object to manufacture a `Uri`.
+    ///
+    /// This method returns an instance of `Builder` which can be usd to
+    /// create a `Uri`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http::Uri;
+    ///
+    /// let uri = Uri::builder()
+    ///     .scheme("https")
+    ///     .authority("hyper.rs")
+    ///     .path_and_query("/")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
     /// Attempt to convert a `Uri` from `Parts`
     pub fn from_parts(src: Parts) -> Result<Uri, InvalidUriParts> {
         if src.scheme.is_some() {


### PR DESCRIPTION
This introduces a `Builder` type for manipulating and building up `Uri`s. Instead of having mutators on `Uri` directly, which would need to return errors, instead this suggests that a user either use a `Builder` from the start, or to convert a `Uri` into via `uri.into_builder()`.

An example looks like:

```rust
let uri = Uri::builder()
    .scheme("https")
    .authority("hyper.rs")
    .path_and_query("/")
    .build()
    .unwrap();
```

It currently only supports setting the 3 distinct parts, not any sub parts (like host or path), but I expect those could be added. This is however generic over `HttpTryFrom`, so you can easily build pieces with `&str`, or `Bytes`, etc.

It's only a start, but related to #206.