### PR TITLE
Document panic on header index

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1864,6 +1864,8 @@ impl<'a, K, T> ops::Index<K> for HeaderMap<T>
 {
     type Output = T;
 
+    /// # Panics
+    /// Using the index operator will cause a panic if the header you're querying isn't set.
     #[inline]
     fn index(&self, index: K) -> &T {
         self.get(index).expect("no entry found for key")


### PR DESCRIPTION
I'm always a bit cautious about the index operator in Rust, it may or may not panic depending on the implementation.
In this case it can panic (which is fine), imho it's always nice to be able to clearly see it in the docs.