### PR TITLE
Optimize size and access of Extensions

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -13,7 +13,9 @@ type AnyMap = HashMap<TypeId, Box<Any + Send + Sync>, BuildHasherDefault<FnvHash
 /// extra data derived from the underlying protocol.
 #[derive(Default)]
 pub struct Extensions {
-    map: AnyMap,
+    // If extensions are never used, no need to carry around an empty HashMap.
+    // That's 3 words. Instead, this is only 1 word.
+    map: Option<Box<AnyMap>>,
 }
 
 impl Extensions {
@@ -21,7 +23,7 @@ impl Extensions {
     #[inline]
     pub fn new() -> Extensions {
         Extensions {
-            map: HashMap::default(),
+            map: None,
         }
     }
 
@@ -40,7 +42,10 @@ impl Extensions {
     /// assert_eq!(ext.insert(9i32), Some(5i32));
     /// ```
     pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
-        self.map.insert(TypeId::of::<T>(), Box::new(val))
+        self
+            .map
+            .get_or_insert_with(|| Box::new(HashMap::default()))
+            .insert(TypeId::of::<T>(), Box::new(val))
             .and_then(|boxed| {
                 //TODO: we can use unsafe and remove double checking the type id
                 (boxed as Box<Any + 'static>)
@@ -63,7 +68,10 @@ impl Extensions {
     /// assert_eq!(ext.get::<i32>(), Some(&5i32));
     /// ```
     pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
-        self.map.get(&TypeId::of::<T>())
+        self
+            .map
+            .as_ref()
+            .and_then(|map| map.get(&TypeId::of::<T>()))
             //TODO: we can use unsafe and remove double checking the type id
             .and_then(|boxed| (&**boxed as &(Any + 'static)).downcast_ref())
     }
@@ -81,7 +89,10 @@ impl Extensions {
     /// assert_eq!(ext.get::<String>().unwrap(), "Hello World");
     /// ```
     pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
-        self.map.get_mut(&TypeId::of::<T>())
+        self
+            .map
+            .as_mut()
+            .and_then(|map| map.get_mut(&TypeId::of::<T>()))
             //TODO: we can use unsafe and remove double checking the type id
             .and_then(|boxed| (&mut **boxed as &mut (Any + 'static)).downcast_mut())
     }
@@ -101,7 +112,10 @@ impl Extensions {
     /// assert!(ext.get::<i32>().is_none());
     /// ```
     pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
-        self.map.remove(&TypeId::of::<T>())
+        self
+            .map
+            .as_mut()
+            .and_then(|map| map.remove(&TypeId::of::<T>()))
             .and_then(|boxed| {
                 //TODO: we can use unsafe and remove double checking the type id
                 (boxed as Box<Any + 'static>)
@@ -125,7 +139,9 @@ impl Extensions {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        self.map.clear();
+        if let Some(ref mut map) = self.map {
+            map.clear();
+        }
     }
 }
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,11 +1,33 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
+use std::hash::{BuildHasherDefault, Hasher};
 use std::fmt;
 
-use fnv::FnvHasher;
+type AnyMap = HashMap<TypeId, Box<Any + Send + Sync>, BuildHasherDefault<IdHasher>>;
 
-type AnyMap = HashMap<TypeId, Box<Any + Send + Sync>, BuildHasherDefault<FnvHasher>>;
+// With TypeIds as keys, there's no need to hash them. They are already hashes
+// themselves, coming from the compiler. The IdHasher just holds the u64 of
+// the TypeId, and then returns it, instead of doing any bit fiddling.
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+
 
 /// A type map of protocol extensions.
 ///


### PR DESCRIPTION
- If the extensions are never used, this change is a straight win, by putting them behind an `Option<Box>`. The size of `Extensions` goes from 3 words to 1 word. If they are accessed, it does mean an allocation occurs, but the size of `Request` and `Response` are still smaller because of it.
- The extensions store a map of `TypeId` to trait objects, and uses the `FnvHasher`. However, `TypeId`s are already hashes themselves, from the compiler, so there's no real need to do any extra hashing. As an example, [futures does the same thing for its task-local-data](https://github.com/rust-lang-nursery/futures-rs/blob/1328fc9e8af5737183df477c7501e6ea24ff2053/src/task_impl/std/data.rs#L68).