### PR TITLE
Uri::from_parts to return SlashInPathMissing

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -137,6 +137,7 @@ enum ErrorKind {
     SchemeMissing,
     AuthorityMissing,
     PathAndQueryMissing,
+    SlashInPathMissing,
     TooLong,
     Empty,
     SchemeTooLong,
@@ -189,6 +190,14 @@ impl Uri {
         } else {
             if src.authority.is_some() && src.path_and_query.is_some() {
                 return Err(ErrorKind::SchemeMissing.into());
+            }
+        }
+
+        if let (&Some(_), &Some(ref path_and_query)) = (&src.authority, &src.path_and_query) {
+            let path = path_and_query.path();
+            if !path.is_empty() && !path.starts_with('/') {
+                // As per RFC3986 sections 3 and 3.3
+                return Err(ErrorKind::SlashInPathMissing.into());
             }
         }
 
@@ -991,6 +1000,7 @@ impl Error for InvalidUri {
             ErrorKind::SchemeMissing => "scheme missing",
             ErrorKind::AuthorityMissing => "authority missing",
             ErrorKind::PathAndQueryMissing => "path missing",
+            ErrorKind::SlashInPathMissing => "slash in path missing",
             ErrorKind::TooLong => "uri too long",
             ErrorKind::Empty => "empty string",
             ErrorKind::SchemeTooLong => "scheme too long",


### PR DESCRIPTION
When running this code:
```
let mut parts = Parts::default();
parts.scheme = Some(Scheme::HTTP);
parts.authority = Some(Authority::from_str("www.example.com").unwrap());
parts.path_and_query = Some(PathAndQuery::from_str("my_path").unwrap());

let uri = Uri::from_parts(parts).unwrap();
println!("{}", uri);
```
the intention would most likely be to print "http://www.example.com/my_path", but in reality it is "http://www.example.commy_path" (notice the missing slash).

Rust playground here: https://play.rust-lang.org/?gist=903f0d760c9b94b358a21540301c2a02&version=stable&mode=debug&edition=2015

This can lead into annoying bugs and furthermore is against the RFC3986 sections 3 and 3.3 where it states that:
```
URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
hier-part   = "//" authority path-abempty
              / path-absolute
              / path-rootless
              / path-empty
path-abempty  = *( "/" segment )
```