### PR TITLE
Fix path double percent parsing

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -49,6 +49,11 @@ impl PathAndQuery {
             match URI_CHARS[b as usize] {
                 0 => {
                     if b == b'%' {
+                        // Check if next character is not %
+                        if i + 2 <= src.len() && b'%' == src[i + 1] {
+                            break;
+                        }
+
                         // Check that there are enough chars for a percent
                         // encoded char
                         let perc_encoded =
@@ -503,5 +508,33 @@ mod tests {
         assert!("/c/world&foo=bar".to_string() > path_and_query);
         assert!(path_and_query > "/a/world&foo=bar".to_string());
         assert!("/a/world&foo=bar".to_string() < path_and_query);
+    }
+
+    #[test]
+    fn double_percent_path() {
+        let double_percent_path = "/your.js?bn=%%val";
+
+        assert!(double_percent_path.parse::<PathAndQuery>().is_ok());
+
+        let path: PathAndQuery = double_percent_path.parse().unwrap();
+        assert_eq!(path, double_percent_path);
+
+        let double_percent_path = "/path%%";
+
+        assert!(double_percent_path.parse::<PathAndQuery>().is_ok());
+    }
+
+    #[test]
+    fn path_ends_with_question_mark() {
+        let path = "/path?%";
+
+        assert!(path.parse::<PathAndQuery>().is_err());
+    }
+
+    #[test]
+    fn path_ends_with_fragment_percent() {
+        let path = "/path#%";
+
+        assert!(path.parse::<PathAndQuery>().is_ok());
     }
 }


### PR DESCRIPTION
Issue: https://github.com/hyperium/http/issues/202

According to RFC https://tools.ietf.org/html/rfc3986#section-2.1

Percent character "%" must be followed by the two hexadecimal digits when is encoded - therefore if percent character is immediately followed by percent character conditional does not hold.