### PR TITLE
Allow more characters in query strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ path = "benches/header_map/mod.rs"
 [[bench]]
 name = "header_value"
 path = "benches/header_value.rs"
+
+[[bench]]
+name = "uri"
+path = "benches/uri.rs"

--- a/benches/uri.rs
+++ b/benches/uri.rs
@@ -1,0 +1,33 @@
+#![feature(test)]
+
+extern crate http;
+extern crate test;
+
+use http::Uri;
+use test::Bencher;
+
+#[bench]
+fn uri_parse_slash(b: &mut Bencher) {
+    b.bytes = 1;
+    b.iter(|| {
+        "/".parse::<Uri>().unwrap();
+    });
+}
+
+#[bench]
+fn uri_parse_relative_medium(b: &mut Bencher) {
+    let s = "/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg";
+    b.bytes = s.len() as u64;
+    b.iter(|| {
+        s.parse::<Uri>().unwrap();
+    });
+}
+
+#[bench]
+fn uri_parse_relative_query(b: &mut Bencher) {
+    let s = "/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg?foo={bar}|baz%13%11quux";
+    b.bytes = s.len() as u64;
+    b.iter(|| {
+        s.parse::<Uri>().unwrap();
+    });
+}

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -67,6 +67,19 @@ impl PathAndQuery {
 
                         i += 3;
                         continue;
+                    } else if query != NONE {
+                        // While queries *should* be percent-encoded, most
+                        // bytes are actually allowed...
+                        // See https://url.spec.whatwg.org/#query-state
+                        //
+                        // Allowed: 0x21 / 0x24 - 0x3B / 0x3D / 0x3F - 0x7E
+                        match b {
+                            0x21 |
+                            0x24...0x3B |
+                            0x3D |
+                            0x3F...0x7E => (),
+                            _ => return Err(ErrorKind::InvalidUriChar.into()),
+                        }
                     } else {
                         return Err(ErrorKind::InvalidUriChar.into());
                     }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -369,6 +369,14 @@ test_parse! {
     port = None,
 }
 
+test_parse! {
+    test_query_permissive,
+    "/?foo={bar|baz}\\^`",
+    [],
+
+    query = Some("foo={bar|baz}\\^`"),
+}
+
 #[test]
 fn test_uri_parse_error() {
     fn err(s: &str) {
@@ -386,6 +394,12 @@ fn test_uri_parse_error() {
     err("http://[::1");
     err("http://::1]");
     err("localhost:8080:3030");
+
+    // illegal queries
+    err("/?foo\rbar");
+    err("/?foo\nbar");
+    err("/?<");
+    err("/?>");
 }
 
 #[test]


### PR DESCRIPTION
Based on https://url.spec.whatwg.org/#query-state:

> If one of the following is true
> - byte is less than 0x21 (!)
> - byte is greater than 0x7E (~)
> - byte is 0x22 ("), 0x23 (#), 0x3C (<), or 0x3E (>)
> - byte is 0x27 (') and url is special
>
> then append byte, percent encoded, to url’s query.
>
> Otherwise, append a code point whose value is byte to url’s query.

Since we aren't normalizing URLs here, this code *denies* bytes mentioned in the first step, instead of percent-encoding.
