### PR TITLE
implement fmt::Display for HeaderName

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1704,6 +1704,12 @@ impl fmt::Debug for HeaderName {
     }
 }
 
+impl fmt::Display for HeaderName {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), fmt)
+    }
+}
+
 impl InvalidHeaderName {
     fn new() -> InvalidHeaderName {
         InvalidHeaderName { _priv: () }


### PR DESCRIPTION
There is an `as_str` method, and plenty of other trait implementations around `HeaderName` being a string, it seems convenient to allow it to be formatted with `{}`.