### PR TITLE
Ignore percent encodings in Uri paths and queries

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -49,11 +49,6 @@ impl PathAndQuery {
             match URI_CHARS[b as usize] {
                 0 => {
                     if b == b'%' {
-                        // Check if next character is not %
-                        if i + 2 <= src.len() && b'%' == src[i + 1] {
-                            break;
-                        }
-
                         // Check that there are enough chars for a percent
                         // encoded char
                         let perc_encoded =
@@ -521,33 +516,5 @@ mod tests {
         assert!("/c/world&foo=bar".to_string() > path_and_query);
         assert!(path_and_query > "/a/world&foo=bar".to_string());
         assert!("/a/world&foo=bar".to_string() < path_and_query);
-    }
-
-    #[test]
-    fn double_percent_path() {
-        let double_percent_path = "/your.js?bn=%%val";
-
-        assert!(double_percent_path.parse::<PathAndQuery>().is_ok());
-
-        let path: PathAndQuery = double_percent_path.parse().unwrap();
-        assert_eq!(path, double_percent_path);
-
-        let double_percent_path = "/path%%";
-
-        assert!(double_percent_path.parse::<PathAndQuery>().is_ok());
-    }
-
-    #[test]
-    fn path_ends_with_question_mark() {
-        let path = "/path?%";
-
-        assert!(path.parse::<PathAndQuery>().is_err());
-    }
-
-    #[test]
-    fn path_ends_with_fragment_percent() {
-        let path = "/path#%";
-
-        assert!(path.parse::<PathAndQuery>().is_ok());
     }
 }


### PR DESCRIPTION
Previously the parsing (`PathAndQuery::from_shared`) checked for two hex digits after a `%`, but the `HEX_DIGIT` array included additional characters beyond valid hexadecimal numbers (like 'Z' and '~'). This was originally introduced in #135 (@carllerche).

The change of #233 introduced a special case leniency for "%%", with some claimed significance by its author @ernestas-poskus, but that handled only one possible case of malformed percent encoding, and did it by effectively aborting remaining checks and parsing (via `break`) for the remainder of the "/path?query#anchor".  I demonstrate this problem in a423e930 (separate branch, not intended for merge). To the extent that this allows injecting things like CRLF into subsequent characters of a `Uri`, which could break HTTP/1.0 request wire format, this could possibly have security implications?   As part of this PR, I first revert the changes from #233, but the remainder of this PR is a better fix for the original #202 as well, as demonstrated by new tests. 

By comparison the WHATWG URL standard (https://url.spec.whatwg.org/) and implementations like the *rust-url* crate simply pass invalid percent encodings through unmodified (only treating these as a soft
SyntaxViolation warning).

Since `Uri` doesn't attempt any normalization of percent-encoded values, this PR simply treats '%' as a valid path or query character, with no special meaning for the subsequent characters.  The '%' character is *not* added to URI_CHARS because we still don't want to accept it, at least in a host name component of the authority.

Compatibility: This shouldn't be a breaking change, because it generally makes `Uri` parsing *more* lenient for the path and query components.  The only exception to that is URIs with "%%" which are now treated uniformly.   `Uri` parsing should be slightly faster without the length, hex digit test and table, and the special case.