### PR TITLE
impl Display for Version

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -54,7 +54,7 @@ impl Default for Version {
     }
 }
 
-impl fmt::Debug for Version {
+impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Http::*;
 
@@ -64,5 +64,11 @@ impl fmt::Debug for Version {
             Http11 => "HTTP/1.1",
             H2     => "HTTP/2.0",
         })
+    }
+}
+
+impl fmt::Debug for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }


### PR DESCRIPTION
`http::Version` could impl `Display` just like `Uri` and `Method`, so that we can use a much consistent way during `format!`

similar code ref: https://github.com/hyperium/http/blob/master/src/uri/mod.rs#L969-L993