### PR TITLE
Fix partial equality for URI with terminating questionmark

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -937,6 +937,10 @@ impl PartialEq<str> for Uri {
         }
 
         if let Some(query) = self.query() {
+            if other.len() == 0 {
+                return query.len() == 0;
+            }
+
             if other[0] != b'?' {
                 return false;
             }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -461,3 +461,11 @@ fn test_authority_uri_parts_round_trip() {
     assert_eq!(uri2, s);
     assert_eq!(uri2.to_string(), s);
 }
+
+#[test]
+fn test_partial_eq_path_with_terminating_questionmark() {
+    let a = "/path";
+    let uri = Uri::from_str("/path?").expect("first parse");
+
+    assert_eq!(uri, a);
+}


### PR DESCRIPTION
When comparing a `str` to a `Uri` instance that has only the `?` without any parameter, the comparison implementation would panic (out-of-bound indexing).

I'm not sure the `return query.len()` is the desired logic, but this fixes the bug and all tests pass.