### PR TITLE
Add serde support for StatusCode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ categories = ["web-programming"]
 bytes = "0.4"
 fnv = "1.0.5"
 itoa = "0.4.1"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 indexmap = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,10 @@ extern crate bytes;
 extern crate fnv;
 extern crate itoa;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 pub mod header;
 pub mod method;
 pub mod request;

--- a/src/status.rs
+++ b/src/status.rs
@@ -40,6 +40,7 @@ use HttpTryFrom;
 /// assert!(StatusCode::OK.is_success());
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StatusCode(u16);
 
 /// A possible error value when converting a `StatusCode` from a `u16` or `&str`


### PR DESCRIPTION
This adds a feature `serde` that for now just enables serialization and deserialization of `StatusCode`.

Other types can easily be added later based on this.

Resolves #273.