### PR TITLE
Add Clone to Request

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -167,6 +167,12 @@ impl Extensions {
     }
 }
 
+impl Clone for Extensions {
+    fn clone(&self) -> Extensions {
+        Extensions::new()
+    }
+}
+
 impl fmt::Debug for Extensions {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Extensions")

--- a/src/request.rs
+++ b/src/request.rs
@@ -153,6 +153,7 @@ use version::Version;
 /// #
 /// # fn main() {}
 /// ```
+#[derive(Clone)]
 pub struct Request<T> {
     head: Parts,
     body: T,
@@ -162,6 +163,7 @@ pub struct Request<T> {
 ///
 /// The HTTP request head consists of a method, uri, version, and a set of
 /// header fields.
+#[derive(Clone)]
 pub struct Parts {
     /// The request's method
     pub method: Method,
@@ -956,5 +958,13 @@ mod tests {
             123u32
         });
         assert_eq!(mapped_request.body(), &123u32);
+    }
+
+    #[test]
+    fn it_can_be_cloned() {
+        let request = Request::builder().body(42i32).unwrap();
+
+        let other_request: Request<_> = request.clone();
+        drop(other_request);
     }
 }


### PR DESCRIPTION
I'm currently using `hyper` and it exposes the Request through the `http` crate here. 

One thing I am currently needing is to `clone` a Request, this would implement the http part of it.

Since `Extensions` uses an `AnyMap` this causes some problems, as a clone is not a complete but a partial clone. I have added a part about documentation here. However, as Extensions seem to be used for 'Only for this Extensions' semantics, this could be a good thing.
