### PR TITLE
Add functions to split URI query parts

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -256,14 +256,14 @@ impl PathAndQuery {
         r
     }
 
-    /// Parses the query string component and return the first value to the given key
+    /// Parses the query string component and return the values to the given key
     ///
     /// # Examples
     ///
     /// ```
     /// # use http::uri::*;
     /// let path_and_query: PathAndQuery = "/hello/world?key=value&foo=bar".parse().unwrap();
-    /// assert_eq!(path_and_query.query_param_first("foo"), Some("bar"));
+    /// assert_eq!(path_and_query.query_param("foo"), Some("bar"));
     /// ```
     pub fn query_param<S: AsRef<str>>(&self, key: S) -> Option<Vec<&str>> {
         match self.query_params().get(key.as_ref()) {

--- a/tests/query_params.rs
+++ b/tests/query_params.rs
@@ -53,14 +53,10 @@ fn path_and_query_param_several_with_multi() {
 }
 
 
-
 #[test]
 fn path_and_query_param_first() {
     let p = PathAndQuery::from_static("/path?key=value1&key=value2");
     assert!(p.query_contains_key("key"), "Query is expected to contain key 'key'");
     assert_eq!(p.query_param_first("key"), Some("value1"), "Key value for 'key' is expected to be 'value1'");
 }
-
-
-
 


### PR DESCRIPTION
Hi,
this PR adds a function to parse the URI query into a HashMap to allow easier retrieval of the values plus some convenience functions. Finally, it is quite easy to just do:
```
let my_query_value = match uri.query_param_first("foo") {
   Some(value) => value,
   None => "my-default-value"
}
```
The code is provided as is and I hope it helps someone. Please be aware that I am relatively new to Rust and hope that the added tests ensure that I did not screw up totally ;-)
Best,
Manuel
