### PR TITLE
Add awareness of HTTP/3

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1013,6 +1013,7 @@ const HEADER_CHARS: [u8; 256] = [
         0,     0,     0,     0,     0,     0                              // 25x
 ];
 
+/// Valid header name characters for HTTP/2.0 and HTTP/3.0
 const HEADER_CHARS_H2: [u8; 256] = [
     //  0      1      2      3      4      5      6      7      8      9
         0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //   x
@@ -1560,8 +1561,8 @@ impl HeaderName {
     /// Converts a slice of bytes to an HTTP header name.
     ///
     /// This function expects the input to only contain lowercase characters.
-    /// This is useful when decoding HTTP/2.0 headers. The HTTP/2.0
-    /// specification requires that all headers be represented in lower case.
+    /// This is useful when decoding HTTP/2.0 or HTTP/3.0 headers. Both
+    /// require that all headers be represented in lower case.
     ///
     /// # Examples
     ///

--- a/src/status.rs
+++ b/src/status.rs
@@ -139,8 +139,9 @@ impl StatusCode {
     /// The reason phrase is defined as being exclusively for human readers. You should avoid
     /// deriving any meaning from it at all costs.
     ///
-    /// Bear in mind also that in HTTP/2.0 the reason phrase is abolished from transmission, and so
-    /// this canonical reason phrase really is the only reason phrase you’ll find.
+    /// Bear in mind also that in HTTP/2.0 and HTTP/3.0 the reason phrase is abolished from
+    /// transmission, and so this canonical reason phrase really is the only reason phrase you’ll
+    /// find.
     ///
     /// # Example
     ///

--- a/src/version.rs
+++ b/src/version.rs
@@ -37,6 +37,9 @@ impl Version {
 
     /// `HTTP/2.0`
     pub const HTTP_2: Version = Version(Http::H2);
+
+    /// `HTTP/3.0`
+    pub const HTTP_3: Version = Version(Http::H3);
 }
 
 #[derive(PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
@@ -45,6 +48,7 @@ enum Http {
     Http10,
     Http11,
     H2,
+    H3,
 }
 
 impl Default for Version {
@@ -63,6 +67,7 @@ impl fmt::Debug for Version {
             Http10 => "HTTP/1.0",
             Http11 => "HTTP/1.1",
             H2     => "HTTP/2.0",
+            H3     => "HTTP/3.0",
         })
     }
 }


### PR DESCRIPTION
The HTTP mapping to the QUIC transport was renamed to HTTP/3 in [Internet Draft version 17](https://tools.ietf.org/html/draft-ietf-quic-http-17).

This PR just adds the basics (enum, string) that acknowledge that HTTP/3 is now the official name.