### PR TITLE
Implementation of test and parsing for protocol relative uris (#300)

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -924,22 +924,20 @@ impl PartialEq<str> for Uri {
         let mut absolute = false;
 
         if let Some(scheme) = self.scheme_part() {
-            let scheme = scheme.as_str().as_bytes();
-            absolute = true;
             
-            //Relative Protocol URI
-            let is_relative_protocol = scheme.len() == 0;
-            let delimiter_width = if is_relative_protocol{ 2 } else {3};
+            let delimiter_width = if let Scheme2::Relative = scheme.inner { 2 } else { 3 };
 
+            let scheme_bytes = scheme.as_str().as_bytes();
+            absolute = true;
 
-            if other.len() < scheme.len() + delimiter_width {
+            if other.len() < scheme_bytes.len() + delimiter_width {
                 return false;
             }
 
-            if !scheme.eq_ignore_ascii_case(&other[..scheme.len()]) {
+            if !scheme_bytes.eq_ignore_ascii_case(&other[..scheme_bytes.len()]) {
                 return false;
             }
-            other = &other[scheme.len()..];
+            other = &other[scheme_bytes.len()..];
 
             if &other[..delimiter_width] != &(b"://"[3-delimiter_width..]) {
                 return false;

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -1036,11 +1036,9 @@ impl Default for Uri {
 impl fmt::Display for Uri {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(scheme) = self.scheme_part() {
-            if let Scheme2::Relative = scheme.inner {
-                write!(f, "//")?
-            }
-            else{
-                write!(f, "{}://",scheme)?
+            match scheme.inner{
+                Scheme2::Relative => write!(f, "//")?,
+                _ => write!(f, "{}://", scheme)?
             }
         }
 

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -293,6 +293,7 @@ impl Scheme2<usize> {
         match s {
             b"http" => Ok(Protocol::Http.into()),
             b"https" => Ok(Protocol::Https.into()),
+            b"//" => Ok(Scheme2::Other(())),
             _ => {
                 if s.len() > MAX_SCHEME_LEN {
                     return Err(ErrorKind::SchemeTooLong.into());
@@ -360,6 +361,11 @@ impl Scheme2<usize> {
                     _ => {}
                 }
             }
+        }
+
+        if s.starts_with(b"//")
+        {
+            return Ok(Scheme2::Other(0))
         }
 
         Ok(Scheme2::None)

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -59,7 +59,7 @@ test_parse! {
     "//some/path/here",
     [],
 
-    scheme_part = part!(""),
+    scheme_part = part!("//"),
     authority_part = part!("some"),
     path = "/path/here",
 }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -55,6 +55,18 @@ macro_rules! test_parse {
 }
 
 test_parse! {
+    test_uri_parse_protocol_relative,
+    "//some/path/here",
+    [],
+
+    scheme_part = part!(""),
+    authority_part = part!("some"),
+    path = "/path/here",
+}
+
+
+
+test_parse! {
     test_uri_parse_path_and_query,
     "/some/path/here?and=then&hello#and-bye",
     [],


### PR DESCRIPTION
Implemented ability to handle protocol relative URIs (#300 )

You'll have to forgive me because I'm just starting out with rust so some of this might not be idiomatic and the test macro framework was/is a bit confusing.

Adding support for protocol relative uris required:
- The assumption that something that indicates scheme is always separated by three characters be turfed.
  - In places that this had an impact I've introduced locals with a name like offset or delimiter width and adjusted some of the magic 3's to use it instead. 
- Scheme matching on // for scheme2::parse and parse_exact
- Changing how as_str works to be able to output uris without a ":"

I ran benches locally and none of them seemed to be impacted by the additional branching