### PR TITLE
Add http::Error::inner_ref and cause

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,12 @@ impl fmt::Display for Error {
 }
 
 impl Error {
+    /// Return true if the underlying error has the same type as T.
+    pub fn is<T: error::Error + 'static>(&self) -> bool {
+        let ie = self.inner_ref();
+        ie.is::<T>()
+    }
+
     /// Return a reference to the lower level, inner error.
     pub fn inner_ref(&self) -> &(error::Error + 'static) {
         use self::ErrorKind::*;
@@ -177,6 +183,9 @@ mod tests {
             assert!(!ie.is::<header::InvalidHeaderValue>());
             assert!( ie.is::<status::InvalidStatusCode>());
             ie.downcast_ref::<status::InvalidStatusCode>().unwrap();
+
+            assert!(!err.is::<header::InvalidHeaderValue>());
+            assert!( err.is::<status::InvalidStatusCode>());
         } else {
             panic!("Bad status allowed!");
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,12 +43,11 @@ impl fmt::Display for Error {
 impl Error {
     /// Return true if the underlying error has the same type as T.
     pub fn is<T: error::Error + 'static>(&self) -> bool {
-        let ie = self.inner_ref();
-        ie.is::<T>()
+        self.get_ref().is::<T>()
     }
 
     /// Return a reference to the lower level, inner error.
-    pub fn inner_ref(&self) -> &(error::Error + 'static) {
+    pub fn get_ref(&self) -> &(error::Error + 'static) {
         use self::ErrorKind::*;
 
         match self.inner {
@@ -82,8 +81,9 @@ impl error::Error for Error {
         }
     }
 
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
-        Some(self.inner_ref())
+        Some(self.get_ref())
     }
 }
 
@@ -179,7 +179,7 @@ mod tests {
     fn inner_error_is_invalid_status_code() {
         if let Err(e) = status::StatusCode::from_u16(6666) {
             let err: Error = e.into();
-            let ie = err.inner_ref();
+            let ie = err.get_ref();
             assert!(!ie.is::<header::InvalidHeaderValue>());
             assert!( ie.is::<status::InvalidStatusCode>());
             ie.downcast_ref::<status::InvalidStatusCode>().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,9 +81,11 @@ impl error::Error for Error {
         }
     }
 
+    // Return any available cause from the inner error. Note the inner error is
+    // not itself the cause.
     #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
-        Some(self.get_ref())
+        self.get_ref().cause()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,25 @@ impl fmt::Display for Error {
     }
 }
 
+impl Error {
+    /// Return a reference to the lower level, inner error.
+    pub fn inner_ref(&self) -> &(error::Error + 'static) {
+        use self::ErrorKind::*;
+
+        match self.inner {
+            StatusCode(ref e) => e,
+            Method(ref e) => e,
+            Uri(ref e) => e,
+            UriShared(ref e) => e,
+            UriParts(ref e) => e,
+            HeaderName(ref e) => e,
+            HeaderNameShared(ref e) => e,
+            HeaderValue(ref e) => e,
+            HeaderValueShared(ref e) => e,
+        }
+    }
+}
+
 impl error::Error for Error {
     fn description(&self) -> &str {
         use self::ErrorKind::*;
@@ -55,6 +74,10 @@ impl error::Error for Error {
             HeaderValue(ref e) => e.description(),
             HeaderValueShared(ref e) => e.description(),
         }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        Some(self.inner_ref())
     }
 }
 
@@ -142,3 +165,20 @@ impl error::Error for Never {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inner_error_is_invalid_status_code() {
+        if let Err(e) = status::StatusCode::from_u16(6666) {
+            let err: Error = e.into();
+            let ie = err.inner_ref();
+            assert!(!ie.is::<header::InvalidHeaderValue>());
+            assert!( ie.is::<status::InvalidStatusCode>());
+            ie.downcast_ref::<status::InvalidStatusCode>().unwrap();
+        } else {
+            panic!("Bad status allowed!");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #302

Provides access by reference to the inner error type.

Also uses `Error::inner_ref` to implement `std::error::Error::cause`, for now. When MSRV is raised to 1.30.0+, this could be used for `Error::source` instead, without any breaking change.
