### PR TITLE
Make eq macro compatible with rustfmt

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1044,14 +1044,17 @@ const HEADER_CHARS_H2: [u8; 256] = [
 ];
 
 macro_rules! eq {
-    ($v:ident[$n:expr] == $a:tt) => {
-        $v[$n] == $a
+    (($($cmp:expr,)*) $v:ident[$n:expr] ==) => {
+        $($cmp) && *
     };
-    ($v:ident[$n:expr] == $a:tt $($rest:tt)+) => {
-        $v[$n] == $a && eq!($v[($n+1)] == $($rest)+)
+    (($($cmp:expr,)*) $v:ident[$n:expr] == $a:tt $($rest:tt)*) => {
+        eq!(($($cmp,)* $v[$n] == $a,) $v[$n+1] == $($rest)*)
     };
-    ($v:ident == $a:tt $($rest:tt)*) => {
-        $v[0] == $a && eq!($v[1] == $($rest)*)
+    ($v:ident == $($rest:tt)+) => {
+        eq!(() $v[0] == $($rest)+)
+    };
+    ($v:ident[$n:expr] == $($rest:tt)+) => {
+        eq!(() $v[$n] == $($rest)+)
     };
 }
 


### PR DESCRIPTION
Rustfmt currently hangs when formatting the expanded code of some of the invocations of eq in this crate. This is a rustfmt bug which I will be reporting, but in the meantime if you are open to it, it is possible to write this macro in a way that generates code that can be formatted more easily and more readably.

Affects `cargo-expand` being able to show expanded code for http (https://github.com/dtolnay/cargo-expand/issues/50#issuecomment-472852153)

Before:

```rust
    (b[0] == b'c' &&
    (b[1] == b'o' &&
    (b[(1 + 1)] == b'n' &&
    (b[((1 + 1) + 1)] == b't' &&
    (b[(((1 + 1) + 1) + 1)] == b'e' &&
    (b[((((1 + 1) + 1) + 1) + 1)] == b'n' &&
    (b[(((((1 + 1) + 1) + 1) + 1) + 1)] == b't' &&
    (b[((((((1 + 1) + 1) + 1) + 1) + 1) + 1)] == b'-' &&
    (b[(((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b's' &&
    (b[((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'e' &&
    (b[(((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'c' &&
    (b[((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'u' &&
    (b[(((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'r' &&
    (b[((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'i' &&
    (b[(((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b't' &&
    (b[((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'y' &&
    (b[(((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'-' &&
    (b[((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'p' &&
    (b[(((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'o' &&
    (b[((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'l' &&
    (b[(((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'i' &&
    (b[((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'c' &&
    (b[(((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'y' &&
    (b[((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'-' &&
    (b[(((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'r' &&
    (b[((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'e' &&
    (b[(((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'p' &&
    (b[((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'o' &&
    (b[(((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'r' &&
    (b[((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b't' &&
    (b[(((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'-' &&
    (b[((((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'o' &&
    (b[(((((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'n' &&
    (b[((((((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'l' &&
    (b[(((((((((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)] == b'y'
    )))))))))))))))))))))))))))))))))))
```

After:

```rust
    b[0] == b'c' &&
    b[0 + 1] == b'o' &&
    b[0 + 1 + 1] == b'n' &&
    b[0 + 1 + 1 + 1] == b't' &&
    b[0 + 1 + 1 + 1 + 1] == b'e' &&
    b[0 + 1 + 1 + 1 + 1 + 1] == b'n' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1] == b't' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'-' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b's' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'e' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'c' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'u' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'r' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'i' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b't' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'y' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'-' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'p' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'o' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'l' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'i' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'c' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'y' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'-' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'r' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'e' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'p' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'o' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'r' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b't' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'-' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'o' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'n' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'l' &&
    b[0 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1] == b'y'
```