### PR TITLE
Create link references to `HeaderName` in `HeaderMap`

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -12,7 +12,9 @@ pub use self::into_header_name::IntoHeaderName;
 
 /// A set of HTTP headers
 ///
-/// `HeaderMap` is an multimap of `HeaderName` to values.
+/// `HeaderMap` is an multimap of [`HeaderName`] to values.
+///
+/// [`HeaderName`]: struct.HeaderName.html
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@ mod extensions;
 pub use convert::HttpTryFrom;
 pub use error::{Error, Result};
 pub use extensions::Extensions;
+#[doc(no_inline)]
 pub use header::HeaderMap;
 pub use method::Method;
 pub use request::Request;


### PR DESCRIPTION
Note that this would only display `http::header::HeaderMap` when searching.
![image](https://user-images.githubusercontent.com/15225902/54411357-afc61d00-4721-11e9-9ca8-f7247eb2721e.png)
