### PR TITLE
Add extensions_mut to request/response builders

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -771,15 +771,15 @@ impl Builder {
     }
 
     /// Get the HTTP Method for this request.
-    /// 
+    ///
     /// By default this is `GET`.
     /// if builder has error, returns None.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use http::*;
-    /// 
+    ///
     /// let mut req = Request::builder();
     /// assert_eq!(req.method_ref(),Some(&Method::GET));
     /// req.method("POST");
@@ -828,13 +828,13 @@ impl Builder {
     }
 
     /// Get the URI for this request
-    /// 
+    ///
     /// By default this is `/`
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use http::*;
-    /// 
+    ///
     /// let mut req = Request::builder();
     /// assert_eq!(req.uri_ref().unwrap().to_string(), "/" );
     /// req.uri("https://www.rust-lang.org/");
@@ -914,9 +914,9 @@ impl Builder {
 
     /// Get header on this request builder.
     /// when builder has error returns None
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use http::*;
     /// # use http::header::HeaderValue;
@@ -941,9 +941,9 @@ impl Builder {
 
     /// Get header on this request builder.
     /// when builder has error returns None
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use http::*;
     /// # use http::header::HeaderValue;
@@ -991,6 +991,19 @@ impl Builder {
             head.extensions.insert(extension);
         }
         self
+    }
+
+    /// Get extensions on this request builder.
+    ///
+    /// When builder has error returns `None`.
+    pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
+        if self.err.is_some() {
+            return None;
+        }
+        match self.head {
+            Some(ref mut head) => Some(&mut head.extensions),
+            None => None
+        }
     }
 
     fn take_parts(&mut self) -> Result<Parts> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -632,9 +632,9 @@ impl Builder {
 
     /// Get header on this response builder.
     /// when builder has error returns None
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use http::*;
     /// # use http::header::HeaderValue;
@@ -659,9 +659,9 @@ impl Builder {
 
     /// Get header on this response builder.
     /// when builder has error returns None
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use http::*;
     /// # use http::header::HeaderValue;
@@ -709,6 +709,19 @@ impl Builder {
             head.extensions.insert(extension);
         }
         self
+    }
+
+    /// Get extensions on this response builder.
+    ///
+    /// When builder has error returns `None`.
+    pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
+        if self.err.is_some() {
+            return None;
+        }
+        match self.head {
+            Some(ref mut head) => Some(&mut head.extensions),
+            None => None
+        }
     }
 
     fn take_parts(&mut self) -> Result<Parts> {


### PR DESCRIPTION
In order to mutate existing extensions already present on a builder, add an `extensions_mut()` method that allows you to access previously set extensions.

My use-case is to create extension traits for `request::Builder` which adds methods that mutate special extensions added on the request. But in order to do that, I must be able to access my extension multiple times before the request is built.