### PR TITLE
Implement HttpTryFrom<HashMap<String,String>> for HeaderMap

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,5 @@
 use Error;
-use header::{HeaderName, HeaderValue};
+use header::{HeaderName, HeaderValue, HeaderMap};
 use method::Method;
 use sealed::Sealed;
 use status::StatusCode;
@@ -56,6 +56,7 @@ reflexive! {
     Uri,
     Method,
     StatusCode,
+    HeaderMap,
     HeaderName,
     HeaderValue,
     Scheme,

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1745,6 +1745,7 @@ impl<T> FromIterator<(HeaderName, T)> for HeaderMap<T>
 /// ```
 impl<'a, K, V> HttpTryFrom<&'a HashMap<K, V>> for HeaderMap<HeaderValue>
     where
+        K: Eq + Hash,
         HeaderName: HttpTryFrom<&'a K>,
         HeaderValue: HttpTryFrom<&'a V>
 {

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1,6 +1,7 @@
 use super::HeaderValue;
 use super::name::{HeaderName, HdrName, InvalidHeaderName};
-use crate::convert::HttpTryFrom;
+use convert::HttpTryFrom;
+use Error;
 use sealed::Sealed;
 
 use std::{fmt, mem, ops, ptr, vec};
@@ -1749,7 +1750,7 @@ impl<COLLECTION, K, V> HttpTryFrom<COLLECTION> for HeaderMap<HeaderValue>
         K: AsRef<str>,
         V: AsRef<str>
 {
-    type Error = ::Error;
+    type Error = Error;
 
     fn try_from(c: COLLECTION) -> Result<Self, Self::Error> {
         c.into_iter()

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -27,10 +27,10 @@ pub use self::into_header_name::IntoHeaderName;
 /// # use http::HeaderMap;
 /// # use http::header::{CONTENT_LENGTH, HOST, LOCATION};
 /// # use http::HttpTryFrom;
-/// let mut headers = HeaderMap::try_from(vec![
-///     (HOST, "example.com"),
-///     (CONTENT_LENGTH, "123")
-/// ]).unwrap();
+/// let mut headers = HeaderMap::new();
+///
+/// headers.insert(HOST, "example.com".parse().unwrap());
+/// headers.insert(CONTENT_LENGTH, "123".parse().unwrap());
 ///
 /// assert!(headers.contains_key(HOST));
 /// assert!(!headers.contains_key(LOCATION));
@@ -1744,15 +1744,15 @@ impl<T> Sealed for HeaderMap<T> {}
 /// let bad_headers: Result<HeaderMap> = HeaderMap::try_from(&headers_hashmap);
 /// assert!(bad_headers.is_err());
 /// ```
-impl<COLLECTION, K, V> HttpTryFrom<COLLECTION> for HeaderMap<HeaderValue>
+impl<C, K, V> HttpTryFrom<C> for HeaderMap<HeaderValue>
     where
-        COLLECTION: IntoIterator<Item=(K, V)>,
+        C: IntoIterator<Item=(K, V)>,
         HeaderName: HttpTryFrom<K>,
         HeaderValue: HttpTryFrom<V>
 {
     type Error = Error;
 
-    fn try_from(c: COLLECTION) -> Result<Self, Self::Error> {
+    fn try_from(c: C) -> Result<Self, Self::Error> {
         c.into_iter()
             .map(|(k, v)| -> ::Result<(HeaderName, HeaderValue)> {
                 let name : HeaderName = k.http_try_into()?;

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1,5 +1,5 @@
 use std::{fmt, mem, ops, ptr, vec};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap};
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::iter::FromIterator;
@@ -1734,14 +1734,6 @@ pub trait IntoHeaderMapAllowed {}
 impl<K, V, S> IntoHeaderMapAllowed for HashMap<K, V, S> {}
 
 impl<'a, K, V, S> IntoHeaderMapAllowed for &'a HashMap<K, V, S> {}
-
-impl<K, V> IntoHeaderMapAllowed for BTreeMap<K, V> {}
-
-impl<'a, K, V> IntoHeaderMapAllowed for &'a BTreeMap<K, V> {}
-
-impl<'a, T> IntoHeaderMapAllowed for &'a [T] {}
-
-impl<T> IntoHeaderMapAllowed for Vec<T> {}
 
 /// Convert a collection of tuples into a HeaderMap
 ///

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1772,6 +1772,14 @@ impl<'a> HttpTryFrom<&'a str> for HeaderName {
     }
 }
 
+impl<'a> HttpTryFrom<&'a String> for HeaderName {
+    type Error = InvalidHeaderName;
+    #[inline]
+    fn try_from(s: &'a String) -> Result<Self, Self::Error> {
+        Self::from_bytes(s.as_bytes())
+    }
+}
+
 impl<'a> HttpTryFrom<&'a [u8]> for HeaderName {
     type Error = InvalidHeaderName;
     #[inline]

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -521,6 +521,14 @@ impl<'a> HttpTryFrom<&'a str> for HeaderValue {
     }
 }
 
+impl<'a> HttpTryFrom<&'a String> for HeaderValue {
+    type Error = InvalidHeaderValue;
+    #[inline]
+    fn try_from(s: &'a String) -> Result<Self, Self::Error> {
+        Self::from_bytes(s.as_bytes())
+    }
+}
+
 impl<'a> HttpTryFrom<&'a [u8]> for HeaderValue {
     type Error = InvalidHeaderValue;
 


### PR DESCRIPTION
This allows an easy conversion from HashMap<String,String>
to HeaderMap<HeaderValue>.

Doing this conversion used to be unnecessarily verbose
because of the required mapping and error type conversions.

The implementation is generic:

```rust
    impl<COLLECTION, K, V> HttpTryFrom<COLLECTION> for HeaderMap<HeaderValue>
    where
        COLLECTION: IntoIterator<Item=(K, V)>,
        K: AsRef<str>,
        V: AsRef<str>
```

so it also works for HashMap<HeaderName, String> and for vectors.

Fixes #325