### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,15 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+      env: DO_BENCHMARKS=1 ALLOW_WARNINGS=1
     # ensure wasm always builds
     - rust: stable
-      script:
-        - rustup target add wasm32-unknown-unknown
-        - cargo build --target=wasm32-unknown-unknown
+      env: TARGET=wasm32-unknown-unknown SKIP_TESTS=1
     # minimum rustc version
     - rust: 1.20.0
-      script: cargo build
+      env: SKIP_TESTS=1
 
-script:
-  - cargo test
-  - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --benches; fi'
+script: bash -x ci/script.sh
 
 notifications:
   email:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+export RUSTFLAGS="${RUSTFLAGS:''}";
+
+if [[ -z "$ALLOW_WARNINGS" ]]; then
+    export RUSTFLAGS="$RUSTFLAGS -D warnings";
+fi
+
+if [[ "$TARGET" ]]; then
+    rustup target add $TARGET;
+else
+    TARGET=$(rustup target list | grep '(default)' | cut -d ' ' -f1)
+fi
+
+cargo build --target="$TARGET"
+
+if [[ -z "$SKIP_TESTS" ]]; then
+    cargo test;
+fi
+
+if [[ "$DO_BENCHMARKS" ]]; then
+    cargo test --benches;
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,13 +151,13 @@
 //!
 //! let uri = "https://www.rust-lang.org/index.html".parse::<Uri>().unwrap();
 //!
-//! assert_eq!(uri.scheme(), Some("https"));
+//! assert_eq!(uri.scheme_str(), Some("https"));
 //! assert_eq!(uri.host(), Some("www.rust-lang.org"));
 //! assert_eq!(uri.path(), "/index.html");
 //! assert_eq!(uri.query(), None);
 //! ```
 
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 extern crate bytes;
 extern crate fnv;

--- a/tests/header_map_fuzz.rs
+++ b/tests/header_map_fuzz.rs
@@ -255,7 +255,7 @@ impl Action {
             }
             Action::Remove { name, val } => {
                 // Just to help track the state, load all associated values.
-                map.get_all(&name).iter().collect::<Vec<_>>();
+                map.get_all(&name).iter().for_each(drop);
 
                 let actual = map.remove(&name);
                 assert_eq!(actual, val);


### PR DESCRIPTION
 - Allow warnings on rust nightly (this allows keeping compatibility with both rust 1.20 and nightly)
 - Create and independent script for CI instead of writing code inside .travis.yml
 - Fix warnings in the tests

Fixes #327