### PR TITLE
[0.2.x] introduce TryFrom impls for path, scheme, uri and authority

### DIFF
--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -1,6 +1,7 @@
 // Deprecated in 1.26, needed until our minimum version is >=1.23.
 #[allow(unused, deprecated)]
 use std::ascii::AsciiExt;
+use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::{cmp, fmt, str};
@@ -26,8 +27,7 @@ impl Authority {
 
     /// Attempt to convert an `Authority` from `Bytes`.
     ///
-    /// This function will be replaced by a `TryFrom` implementation once the
-    /// trait lands in stable.
+    /// This function has been replaced by `TryFrom` implementation.
     ///
     /// # Examples
     ///
@@ -46,15 +46,7 @@ impl Authority {
     /// # }
     /// ```
     pub fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
-        let authority_end = Authority::parse_non_empty(&s[..]).map_err(InvalidUriBytes)?;
-
-        if authority_end != s.len() {
-            return Err(ErrorKind::InvalidUriChar.into());
-        }
-
-        Ok(Authority {
-            data: unsafe { ByteStr::from_utf8_unchecked(s) },
-        })
+        TryFrom::try_from(s)
     }
 
     /// Attempt to convert an `Authority` from a static string.
@@ -266,6 +258,40 @@ impl Authority {
     #[inline]
     pub fn into_bytes(self) -> Bytes {
         self.into()
+    }
+}
+
+impl TryFrom<Bytes> for Authority {
+    type Error = InvalidUriBytes;
+    /// Attempt to convert an `Authority` from `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate http;
+    /// # use http::uri::*;
+    /// extern crate bytes;
+    ///
+    /// use std::convert::TryFrom;
+    /// use bytes::Bytes;
+    ///
+    /// # pub fn main() {
+    /// let bytes = Bytes::from("example.com");
+    /// let authority = Authority::try_from(bytes).unwrap();
+    ///
+    /// assert_eq!(authority.host(), "example.com");
+    /// # }
+    /// ```
+    fn try_from(s: Bytes) -> Result<Self, Self::Error> {
+        let authority_end = Authority::parse_non_empty(&s[..]).map_err(InvalidUriBytes)?;
+
+        if authority_end != s.len() {
+            return Err(ErrorKind::InvalidUriChar.into());
+        }
+
+        Ok(Authority {
+            data: unsafe { ByteStr::from_utf8_unchecked(s) },
+        })
     }
 }
 


### PR DESCRIPTION
This is a redo of https://github.com/hyperium/http/pull/308 on the 0.2.x branch

- This PR introduces `TryFrom`, however doesn't remove `HttpTryFrom` or change other bits in any way, to keep the PR small and unblock others to continue this work. 
- Further PRs can remove `HttpTryFrom` completely if so required. 

/cc @seanmonstar @davidbarsky 