### PR TITLE
0.2.x: Update rand and quickcheck dev deps with usage changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ itoa = "0.4.1"
 
 [dev-dependencies]
 indexmap = "1.0"
-quickcheck = "0.6"
-rand = "0.4"
+quickcheck = "0.9.0"
+rand = "0.7.0"
 seahash = "3.0.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/tests/header_map_fuzz.rs
+++ b/tests/header_map_fuzz.rs
@@ -1,10 +1,10 @@
-use quickcheck;
-
 use http::header::*;
 use http::*;
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-use rand::{Rng, SeedableRng, StdRng};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
 
 use std::collections::HashMap;
 
@@ -21,7 +21,7 @@ fn header_map_fuzz() {
 #[derive(Debug, Clone)]
 struct Fuzz {
     // The magic seed that makes the test case reproducible
-    seed: [usize; 4],
+    seed: [u8; 32],
 
     // Actions to perform
     steps: Vec<Step>,
@@ -68,9 +68,9 @@ struct AltMap {
 }
 
 impl Fuzz {
-    fn new(seed: [usize; 4]) -> Fuzz {
+    fn new(seed: [u8; 32]) -> Fuzz {
         // Seed the RNG
-        let mut rng = StdRng::from_seed(&seed);
+        let mut rng = StdRng::from_seed(seed);
 
         let mut steps = vec![];
         let mut expect = AltMap::default();
@@ -110,7 +110,7 @@ impl Fuzz {
 
 impl Arbitrary for Fuzz {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        Fuzz::new(quickcheck::Rng::gen(g))
+        Fuzz::new(Rng::gen(g))
     }
 }
 
@@ -189,7 +189,7 @@ impl AltMap {
 
     /// Negative numbers weigh finding an existing header higher
     fn gen_name(&self, weight: i32, rng: &mut StdRng) -> HeaderName {
-        let mut existing = rng.gen_weighted_bool(weight.abs() as u32);
+        let mut existing = rng.gen_ratio(1, weight.abs() as u32);
 
         if weight < 0 {
             existing = !existing;
@@ -249,7 +249,7 @@ impl Action {
             }
             Action::Remove { name, val } => {
                 // Just to help track the state, load all associated values.
-                map.get_all(&name).iter().for_each(drop);
+                let _ = map.get_all(&name).iter().collect::<Vec<_>>();
 
                 let actual = map.remove(&name);
                 assert_eq!(actual, val);
@@ -262,84 +262,90 @@ impl Action {
 }
 
 fn gen_header_name(g: &mut StdRng) -> HeaderName {
-    if g.gen_weighted_bool(2) {
-        g.choose(&[
-            header::ACCEPT,
-            header::ACCEPT_CHARSET,
-            header::ACCEPT_ENCODING,
-            header::ACCEPT_LANGUAGE,
-            header::ACCEPT_RANGES,
-            header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
-            header::ACCESS_CONTROL_ALLOW_HEADERS,
-            header::ACCESS_CONTROL_ALLOW_METHODS,
-            header::ACCESS_CONTROL_ALLOW_ORIGIN,
-            header::ACCESS_CONTROL_EXPOSE_HEADERS,
-            header::ACCESS_CONTROL_MAX_AGE,
-            header::ACCESS_CONTROL_REQUEST_HEADERS,
-            header::ACCESS_CONTROL_REQUEST_METHOD,
-            header::AGE,
-            header::ALLOW,
-            header::ALT_SVC,
-            header::AUTHORIZATION,
-            header::CACHE_CONTROL,
-            header::CONNECTION,
-            header::CONTENT_DISPOSITION,
-            header::CONTENT_ENCODING,
-            header::CONTENT_LANGUAGE,
-            header::CONTENT_LENGTH,
-            header::CONTENT_LOCATION,
-            header::CONTENT_RANGE,
-            header::CONTENT_SECURITY_POLICY,
-            header::CONTENT_SECURITY_POLICY_REPORT_ONLY,
-            header::CONTENT_TYPE,
-            header::COOKIE,
-            header::DNT,
-            header::DATE,
-            header::ETAG,
-            header::EXPECT,
-            header::EXPIRES,
-            header::FORWARDED,
-            header::FROM,
-            header::HOST,
-            header::IF_MATCH,
-            header::IF_MODIFIED_SINCE,
-            header::IF_NONE_MATCH,
-            header::IF_RANGE,
-            header::IF_UNMODIFIED_SINCE,
-            header::LAST_MODIFIED,
-            header::LINK,
-            header::LOCATION,
-            header::MAX_FORWARDS,
-            header::ORIGIN,
-            header::PRAGMA,
-            header::PROXY_AUTHENTICATE,
-            header::PROXY_AUTHORIZATION,
-            header::PUBLIC_KEY_PINS,
-            header::PUBLIC_KEY_PINS_REPORT_ONLY,
-            header::RANGE,
-            header::REFERER,
-            header::REFERRER_POLICY,
-            header::RETRY_AFTER,
-            header::SERVER,
-            header::SET_COOKIE,
-            header::STRICT_TRANSPORT_SECURITY,
-            header::TE,
-            header::TRAILER,
-            header::TRANSFER_ENCODING,
-            header::USER_AGENT,
-            header::UPGRADE,
-            header::UPGRADE_INSECURE_REQUESTS,
-            header::VARY,
-            header::VIA,
-            header::WARNING,
-            header::WWW_AUTHENTICATE,
-            header::X_CONTENT_TYPE_OPTIONS,
-            header::X_DNS_PREFETCH_CONTROL,
-            header::X_FRAME_OPTIONS,
-            header::X_XSS_PROTECTION,
-        ])
-        .unwrap()
-        .clone()
+    const STANDARD_HEADERS: &'static [HeaderName] = &[
+        header::ACCEPT,
+        header::ACCEPT_CHARSET,
+        header::ACCEPT_ENCODING,
+        header::ACCEPT_LANGUAGE,
+        header::ACCEPT_RANGES,
+        header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
+        header::ACCESS_CONTROL_ALLOW_HEADERS,
+        header::ACCESS_CONTROL_ALLOW_METHODS,
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        header::ACCESS_CONTROL_EXPOSE_HEADERS,
+        header::ACCESS_CONTROL_MAX_AGE,
+        header::ACCESS_CONTROL_REQUEST_HEADERS,
+        header::ACCESS_CONTROL_REQUEST_METHOD,
+        header::AGE,
+        header::ALLOW,
+        header::ALT_SVC,
+        header::AUTHORIZATION,
+        header::CACHE_CONTROL,
+        header::CONNECTION,
+        header::CONTENT_DISPOSITION,
+        header::CONTENT_ENCODING,
+        header::CONTENT_LANGUAGE,
+        header::CONTENT_LENGTH,
+        header::CONTENT_LOCATION,
+        header::CONTENT_RANGE,
+        header::CONTENT_SECURITY_POLICY,
+        header::CONTENT_SECURITY_POLICY_REPORT_ONLY,
+        header::CONTENT_TYPE,
+        header::COOKIE,
+        header::DNT,
+        header::DATE,
+        header::ETAG,
+        header::EXPECT,
+        header::EXPIRES,
+        header::FORWARDED,
+        header::FROM,
+        header::HOST,
+        header::IF_MATCH,
+        header::IF_MODIFIED_SINCE,
+        header::IF_NONE_MATCH,
+        header::IF_RANGE,
+        header::IF_UNMODIFIED_SINCE,
+        header::LAST_MODIFIED,
+        header::LINK,
+        header::LOCATION,
+        header::MAX_FORWARDS,
+        header::ORIGIN,
+        header::PRAGMA,
+        header::PROXY_AUTHENTICATE,
+        header::PROXY_AUTHORIZATION,
+        header::PUBLIC_KEY_PINS,
+        header::PUBLIC_KEY_PINS_REPORT_ONLY,
+        header::RANGE,
+        header::REFERER,
+        header::REFERRER_POLICY,
+        header::REFRESH,
+        header::RETRY_AFTER,
+        header::SEC_WEBSOCKET_ACCEPT,
+        header::SEC_WEBSOCKET_EXTENSIONS,
+        header::SEC_WEBSOCKET_KEY,
+        header::SEC_WEBSOCKET_PROTOCOL,
+        header::SEC_WEBSOCKET_VERSION,
+        header::SERVER,
+        header::SET_COOKIE,
+        header::STRICT_TRANSPORT_SECURITY,
+        header::TE,
+        header::TRAILER,
+        header::TRANSFER_ENCODING,
+        header::UPGRADE,
+        header::UPGRADE_INSECURE_REQUESTS,
+        header::USER_AGENT,
+        header::VARY,
+        header::VIA,
+        header::WARNING,
+        header::WWW_AUTHENTICATE,
+        header::X_CONTENT_TYPE_OPTIONS,
+        header::X_DNS_PREFETCH_CONTROL,
+        header::X_FRAME_OPTIONS,
+        header::X_XSS_PROTECTION,
+    ];
+
+    if g.gen_ratio(1, 2) {
+        STANDARD_HEADERS.choose(g).unwrap().clone()
     } else {
         let value = gen_string(g, 1, 25);
         HeaderName::from_bytes(value.as_bytes()).unwrap()
@@ -355,7 +361,8 @@ fn gen_string(g: &mut StdRng, min: usize, max: usize) -> String {
     let bytes: Vec<_> = (min..max)
         .map(|_| {
             // Chars to pick from
-            g.choose(b"ABCDEFGHIJKLMNOPQRSTUVabcdefghilpqrstuvwxyz----")
+            b"ABCDEFGHIJKLMNOPQRSTUVabcdefghilpqrstuvwxyz----"
+                .choose(g)
                 .unwrap()
                 .clone()
         })


### PR DESCRIPTION
A recent quickcheck release supports upgrading dev depedencies to include the single version 0.7.0 rand, with associated usage changes.  This change requires rust 1.31.0 even for `cargo build` or `cargo check`, so best for 0.2.x branch, which already has MSRV at 1.36.0.