### PR TITLE
Improve Debug format of error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@ use uri;
 /// functions in this crate, but all other errors can be converted to this
 /// error. Consumers of this crate can typically consume and work with this form
 /// of error for conversions with the `?` operator.
-#[derive(Debug)]
 pub struct Error {
     inner: ErrorKind,
 }
@@ -21,7 +20,6 @@ pub struct Error {
 /// A `Result` typedef to use with the `http::Error` type
 pub type Result<T> = result::Result<T, Error>;
 
-#[derive(Debug)]
 enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),
@@ -34,9 +32,18 @@ enum ErrorKind {
     HeaderValueShared(header::InvalidHeaderValueBytes),
 }
 
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("http::Error")
+            // Skip the noise of the ErrorKind enum
+            .field(&self.get_ref())
+            .finish()
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        error::Error::description(self).fmt(f)
+        fmt::Display::fmt(self.get_ref(), f)
     }
 }
 

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -56,7 +56,6 @@ struct MaybeLower<'a> {
 }
 
 /// A possible error when converting a `HeaderName` from another type.
-#[derive(Debug)]
 pub struct InvalidHeaderName {
     _priv: (),
 }
@@ -2012,6 +2011,14 @@ impl<'a> PartialEq<HeaderName> for &'a str {
     #[inline]
     fn eq(&self, other: &HeaderName) -> bool {
         *other == *self
+    }
+}
+
+impl fmt::Debug for InvalidHeaderName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InvalidHeaderName")
+            // skip _priv noise
+            .finish()
     }
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -25,7 +25,6 @@ pub struct HeaderValue {
 
 /// A possible error when converting a `HeaderValue` from a string or byte
 /// slice.
-#[derive(Debug)]
 pub struct InvalidHeaderValue {
     _priv: (),
 }
@@ -587,6 +586,14 @@ fn is_visible_ascii(b: u8) -> bool {
 #[inline]
 fn is_valid(b: u8) -> bool {
     b >= 32 && b != 127 || b == b'\t'
+}
+
+impl fmt::Debug for InvalidHeaderValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InvalidHeaderValue")
+            // skip _priv noise
+            .finish()
+    }
 }
 
 impl fmt::Display for InvalidHeaderValue {

--- a/src/method.rs
+++ b/src/method.rs
@@ -45,7 +45,6 @@ use std::str::FromStr;
 pub struct Method(Inner);
 
 /// A possible error value when converting `Method` from bytes.
-#[derive(Debug)]
 pub struct InvalidMethod {
     _priv: (),
 }
@@ -387,6 +386,14 @@ impl InvalidMethod {
         InvalidMethod {
             _priv: (),
         }
+    }
+}
+
+impl fmt::Debug for InvalidMethod {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InvalidMethod")
+            // skip _priv noise
+            .finish()
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -46,7 +46,6 @@ pub struct StatusCode(u16);
 ///
 /// This error indicates that the supplied input was not a valid number, was less
 /// than 100, or was greater than 599.
-#[derive(Debug)]
 pub struct InvalidStatusCode {
     _priv: (),
 }
@@ -284,14 +283,6 @@ impl HttpTryFrom<u16> for StatusCode {
     }
 }
 
-impl InvalidStatusCode {
-    fn new() -> InvalidStatusCode {
-        InvalidStatusCode {
-            _priv: (),
-        }
-    }
-}
-
 macro_rules! status_codes {
     (
         $(
@@ -510,6 +501,22 @@ status_codes! {
     /// 511 Network Authentication Required
     /// [[RFC6585](https://tools.ietf.org/html/rfc6585)]
     (511, NETWORK_AUTHENTICATION_REQUIRED, "Network Authentication Required");
+}
+
+impl InvalidStatusCode {
+    fn new() -> InvalidStatusCode {
+        InvalidStatusCode {
+            _priv: (),
+        }
+    }
+}
+
+impl fmt::Debug for InvalidStatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InvalidStatusCode")
+            // skip _priv noise
+            .finish()
+    }
 }
 
 impl fmt::Display for InvalidStatusCode {


### PR DESCRIPTION
For an example of the change, when using in reqwest:

Before:

```
Error { kind: Builder, source: Error { inner: HeaderName(InvalidHeaderName { _priv: () }) } }
```

After:

```
Error { kind: Builder, source: http::Error(InvalidHeaderName) }
```
