### PR TITLE
fix capacity overflows in HeaderMap::reserve

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -638,6 +638,8 @@ impl<T> HeaderMap<T> {
 
         if cap > self.indices.len() {
             let cap = cap.next_power_of_two();
+            assert!(cap < MAX_SIZE, "header map reserve over max capacity");
+            assert!(cap != 0, "header map reserve overflowed");
 
             if self.entries.len() == 0 {
                 self.mask = cap - 1;

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -38,6 +38,22 @@ fn smoke() {
 }
 
 #[test]
+#[should_panic]
+fn reserve_over_capacity() {
+    // See https://github.com/hyperium/http/issues/352
+    let mut headers = HeaderMap::<u32>::with_capacity(32);
+    headers.reserve(50_000); // over MAX_SIZE
+}
+
+#[test]
+#[should_panic]
+fn reserve_overflow() {
+    // See https://github.com/hyperium/http/issues/352
+    let mut headers = HeaderMap::<u32>::with_capacity(0);
+    headers.reserve(std::usize::MAX); // next_power_of_two overflows
+}
+
+#[test]
 fn drain() {
     let mut headers = HeaderMap::new();
 


### PR DESCRIPTION
Fixes #352 