### PR TITLE
Revert "Refactor Method::is_idempotent"

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -206,9 +206,13 @@ impl Method {
     /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.2) for
     /// more words.
     pub fn is_idempotent(&self) -> bool {
-        match self.0 {
-            Put | Delete | _ if self.is_safe() => true,
-            _ => false
+        if self.is_safe() {
+            true
+        } else {
+            match self.0 {
+                Put | Delete => true,
+                _ => false
+            }
         }
     }
 


### PR DESCRIPTION
Reverts hyperium/http#348

is_idempotent currently incorrectly returns false for PUT and DELETE.