### PR TITLE
Fix is_idempotent

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -207,8 +207,8 @@ impl Method {
     /// more words.
     pub fn is_idempotent(&self) -> bool {
         match self.0 {
-            Put | Delete | _ if self.is_safe() => true,
-            _ => false
+            Put | Delete => true,
+            _ => self.is_safe(),
         }
     }
 
@@ -392,4 +392,18 @@ fn test_method_eq() {
 fn test_invalid_method() {
     assert!(Method::from_str("").is_err());
     assert!(Method::from_bytes(b"").is_err());
+}
+
+#[test]
+fn test_is_idempotent() {
+    assert!(Method::OPTIONS.is_idempotent());
+    assert!(Method::GET.is_idempotent());
+    assert!(Method::PUT.is_idempotent());
+    assert!(Method::DELETE.is_idempotent());
+    assert!(Method::HEAD.is_idempotent());
+    assert!(Method::TRACE.is_idempotent());
+
+    assert!(!Method::POST.is_idempotent());
+    assert!(!Method::CONNECT.is_idempotent());
+    assert!(!Method::PATCH.is_idempotent());
 }


### PR DESCRIPTION
Whoops, I forgot that an match guard applies to whole arm and not the branch. This PR fixes that.