### PR TITLE
Remove Bytes from the public API

### DIFF
--- a/benches/header_value.rs
+++ b/benches/header_value.rs
@@ -14,7 +14,7 @@ fn from_shared_short(b: &mut Bencher) {
     b.bytes = SHORT.len() as u64;
     let bytes = Bytes::from_static(SHORT);
     b.iter(|| {
-        HeaderValue::from_shared(bytes.clone()).unwrap();
+        HeaderValue::from_maybe_shared(bytes.clone()).unwrap();
     });
 }
 
@@ -23,7 +23,7 @@ fn from_shared_long(b: &mut Bencher) {
     b.bytes = LONG.len() as u64;
     let bytes = Bytes::from_static(LONG);
     b.iter(|| {
-        HeaderValue::from_shared(bytes.clone()).unwrap();
+        HeaderValue::from_maybe_shared(bytes.clone()).unwrap();
     });
 }
 
@@ -32,7 +32,7 @@ fn from_shared_unchecked_short(b: &mut Bencher) {
     b.bytes = SHORT.len() as u64;
     let bytes = Bytes::from_static(SHORT);
     b.iter(|| unsafe {
-        HeaderValue::from_shared_unchecked(bytes.clone());
+        HeaderValue::from_maybe_shared_unchecked(bytes.clone());
     });
 }
 
@@ -41,6 +41,6 @@ fn from_shared_unchecked_long(b: &mut Bencher) {
     b.bytes = LONG.len() as u64;
     let bytes = Bytes::from_static(LONG);
     b.iter(|| unsafe {
-        HeaderValue::from_shared_unchecked(bytes.clone());
+        HeaderValue::from_maybe_shared_unchecked(bytes.clone());
     });
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,17 @@
+macro_rules! if_downcast_into {
+    ($in_ty:ty, $out_ty:ty, $val:ident, $body:expr) => ({
+        if std::any::TypeId::of::<$in_ty>() == std::any::TypeId::of::<$out_ty>() {
+            // Store the value in an `Option` so we can `take`
+            // it after casting to `&mut dyn Any`.
+            let mut slot = Some($val);
+            // Re-write the `$val` ident with the downcasted value.
+            let $val = (&mut slot as &mut dyn std::any::Any)
+                .downcast_mut::<Option<$out_ty>>()
+                .unwrap()
+                .take()
+                .unwrap();
+            // Run the $body in scope of the replaced val.
+            $body
+        }
+    })
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,12 +24,9 @@ enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),
     Uri(uri::InvalidUri),
-    UriShared(uri::InvalidUriBytes),
     UriParts(uri::InvalidUriParts),
     HeaderName(header::InvalidHeaderName),
-    HeaderNameShared(header::InvalidHeaderNameBytes),
     HeaderValue(header::InvalidHeaderValue),
-    HeaderValueShared(header::InvalidHeaderValueBytes),
 }
 
 impl fmt::Debug for Error {
@@ -61,12 +58,9 @@ impl Error {
             StatusCode(ref e) => e,
             Method(ref e) => e,
             Uri(ref e) => e,
-            UriShared(ref e) => e,
             UriParts(ref e) => e,
             HeaderName(ref e) => e,
-            HeaderNameShared(ref e) => e,
             HeaderValue(ref e) => e,
-            HeaderValueShared(ref e) => e,
         }
     }
 }
@@ -79,12 +73,9 @@ impl error::Error for Error {
             StatusCode(ref e) => e.description(),
             Method(ref e) => e.description(),
             Uri(ref e) => e.description(),
-            UriShared(ref e) => e.description(),
             UriParts(ref e) => e.description(),
             HeaderName(ref e) => e.description(),
-            HeaderNameShared(ref e) => e.description(),
             HeaderValue(ref e) => e.description(),
-            HeaderValueShared(ref e) => e.description(),
         }
     }
 
@@ -119,14 +110,6 @@ impl From<uri::InvalidUri> for Error {
     }
 }
 
-impl From<uri::InvalidUriBytes> for Error {
-    fn from(err: uri::InvalidUriBytes) -> Error {
-        Error {
-            inner: ErrorKind::UriShared(err),
-        }
-    }
-}
-
 impl From<uri::InvalidUriParts> for Error {
     fn from(err: uri::InvalidUriParts) -> Error {
         Error {
@@ -143,26 +126,10 @@ impl From<header::InvalidHeaderName> for Error {
     }
 }
 
-impl From<header::InvalidHeaderNameBytes> for Error {
-    fn from(err: header::InvalidHeaderNameBytes) -> Error {
-        Error {
-            inner: ErrorKind::HeaderNameShared(err),
-        }
-    }
-}
-
 impl From<header::InvalidHeaderValue> for Error {
     fn from(err: header::InvalidHeaderValue) -> Error {
         Error {
             inner: ErrorKind::HeaderValue(err),
-        }
-    }
-}
-
-impl From<header::InvalidHeaderValueBytes> for Error {
-    fn from(err: header::InvalidHeaderValueBytes) -> Error {
-        Error {
-            inner: ErrorKind::HeaderValueShared(err),
         }
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -78,8 +78,8 @@ pub use self::map::{
     AsHeaderName, Drain, Entry, GetAll, HeaderMap, IntoHeaderName, IntoIter, Iter, IterMut, Keys,
     OccupiedEntry, VacantEntry, ValueDrain, ValueIter, ValueIterMut, Values, ValuesMut,
 };
-pub use self::name::{HeaderName, InvalidHeaderName, InvalidHeaderNameBytes};
-pub use self::value::{HeaderValue, InvalidHeaderValue, InvalidHeaderValueBytes, ToStrError};
+pub use self::name::{HeaderName, InvalidHeaderName};
+pub use self::value::{HeaderValue, InvalidHeaderValue, ToStrError};
 
 // Use header name constants
 pub use self::name::{

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -122,14 +122,14 @@ macro_rules! standard_headers {
                 // Test lower case
                 let name_bytes = name.as_bytes();
                 let bytes: Bytes =
-                    HeaderName::from_bytes(name_bytes).unwrap().into();
+                    HeaderName::from_bytes(name_bytes).unwrap().inner.into();
                 assert_eq!(bytes, name_bytes);
                 assert_eq!(HeaderName::from_bytes(name_bytes).unwrap(), std);
 
                 // Test upper case
                 let upper = name.to_uppercase().to_string();
                 let bytes: Bytes =
-                    HeaderName::from_bytes(upper.as_bytes()).unwrap().into();
+                    HeaderName::from_bytes(upper.as_bytes()).unwrap().inner.into();
                 assert_eq!(bytes, name.as_bytes());
                 assert_eq!(HeaderName::from_bytes(upper.as_bytes()).unwrap(),
                            std);
@@ -1809,6 +1809,10 @@ impl HeaderName {
             Repr::Custom(ref v) => &*v.0,
         }
     }
+
+    pub(super) fn into_bytes(self) -> Bytes {
+        self.inner.into()
+    }
 }
 
 impl FromStr for HeaderName {
@@ -1881,13 +1885,6 @@ impl From<Custom> for Bytes {
     }
 }
 
-impl From<HeaderName> for Bytes {
-    #[inline]
-    fn from(name: HeaderName) -> Bytes {
-        name.inner.into()
-    }
-}
-
 impl<'a> TryFrom<&'a str> for HeaderName {
     type Error = InvalidHeaderName;
     #[inline]
@@ -1909,14 +1906,6 @@ impl<'a> TryFrom<&'a [u8]> for HeaderName {
     #[inline]
     fn try_from(s: &'a [u8]) -> Result<Self, Self::Error> {
         Self::from_bytes(s)
-    }
-}
-
-impl TryFrom<Bytes> for HeaderName {
-    type Error = InvalidHeaderNameBytes;
-    #[inline]
-    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        Self::from_bytes(bytes.as_ref()).map_err(InvalidHeaderNameBytes)
     }
 }
 

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -60,10 +60,6 @@ pub struct InvalidHeaderName {
     _priv: (),
 }
 
-/// A possible error when converting a `HeaderName` from another type.
-#[derive(Debug)]
-pub struct InvalidHeaderNameBytes(InvalidHeaderName);
-
 macro_rules! standard_headers {
     (
         $(
@@ -2014,18 +2010,6 @@ impl fmt::Display for InvalidHeaderName {
 impl Error for InvalidHeaderName {
     fn description(&self) -> &str {
         "invalid HTTP header name"
-    }
-}
-
-impl fmt::Display for InvalidHeaderNameBytes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Error for InvalidHeaderNameBytes {
-    fn description(&self) -> &str {
-        self.0.description()
     }
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -28,11 +28,6 @@ pub struct InvalidHeaderValue {
     _priv: (),
 }
 
-/// A possible error when converting a `HeaderValue` from a string or byte
-/// slice.
-#[derive(Debug)]
-pub struct InvalidHeaderValueBytes(InvalidHeaderValue);
-
 /// A possible error when converting a `HeaderValue` to a string representation.
 ///
 /// Header field values may contain opaque bytes, in which case it is not
@@ -161,8 +156,8 @@ impl HeaderValue {
     /// This function is intended to be replaced in the future by a `TryFrom`
     /// implementation once the trait is stabilized in std.
     #[inline]
-    fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
-        HeaderValue::try_from_generic(src, std::convert::identity).map_err(InvalidHeaderValueBytes)
+    fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValue> {
+        HeaderValue::try_from_generic(src, std::convert::identity)
     }
 
     /*
@@ -176,8 +171,6 @@ impl HeaderValue {
             match HeaderValue::from_shared(src) {
                 Ok(val) => val,
                 Err(_err) => {
-                    //TODO: if the Bytes were part of the InvalidHeaderValueBytes,
-                    //this message could include the invalid bytes.
                     panic!("HeaderValue::from_shared_unchecked() with invalid bytes");
                 }
             }
@@ -511,7 +504,7 @@ impl<'a> TryFrom<&'a [u8]> for HeaderValue {
 }
 
 impl TryFrom<String> for HeaderValue {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     #[inline]
     fn try_from(t: String) -> Result<Self, Self::Error> {
@@ -520,7 +513,7 @@ impl TryFrom<String> for HeaderValue {
 }
 
 impl TryFrom<Vec<u8>> for HeaderValue {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     #[inline]
     fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
@@ -568,18 +561,6 @@ impl fmt::Display for InvalidHeaderValue {
 impl Error for InvalidHeaderValue {
     fn description(&self) -> &str {
         "failed to parse header value"
-    }
-}
-
-impl fmt::Display for InvalidHeaderValueBytes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Error for InvalidHeaderValueBytes {
-    fn description(&self) -> &str {
-        self.0.description()
     }
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -161,10 +161,11 @@ impl HeaderValue {
     /// This function is intended to be replaced in the future by a `TryFrom`
     /// implementation once the trait is stabilized in std.
     #[inline]
-    pub fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
+    fn from_shared(src: Bytes) -> Result<HeaderValue, InvalidHeaderValueBytes> {
         HeaderValue::try_from_generic(src, std::convert::identity).map_err(InvalidHeaderValueBytes)
     }
 
+    /*
     /// Convert a `Bytes` directly into a `HeaderValue` without validating.
     ///
     /// This function does NOT validate that illegal bytes are not contained
@@ -187,6 +188,7 @@ impl HeaderValue {
             }
         }
     }
+    */
 
     fn try_from_generic<T: AsRef<[u8]>, F: FnOnce(T) -> Bytes>(src: T, into: F) -> Result<HeaderValue, InvalidHeaderValue> {
         for &b in src.as_ref() {
@@ -357,7 +359,7 @@ impl From<HeaderName> for HeaderValue {
     #[inline]
     fn from(h: HeaderName) -> HeaderValue {
         HeaderValue {
-            inner: h.into(),
+            inner: h.into_bytes(),
             is_sensitive: false,
         }
     }
@@ -475,13 +477,6 @@ impl FromStr for HeaderValue {
     }
 }
 
-impl From<HeaderValue> for Bytes {
-    #[inline]
-    fn from(value: HeaderValue) -> Bytes {
-        value.inner
-    }
-}
-
 impl<'a> From<&'a HeaderValue> for HeaderValue {
     #[inline]
     fn from(t: &'a HeaderValue) -> Self {
@@ -530,15 +525,6 @@ impl TryFrom<Vec<u8>> for HeaderValue {
     #[inline]
     fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
         HeaderValue::from_shared(vec.into())
-    }
-}
-
-impl TryFrom<Bytes> for HeaderValue {
-    type Error = InvalidHeaderValueBytes;
-
-    #[inline]
-    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        HeaderValue::from_shared(bytes)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,9 @@ extern crate doc_comment;
 #[cfg(test)]
 doctest!("../README.md");
 
+#[macro_use]
+mod convert;
+
 pub mod header;
 pub mod method;
 pub mod request;

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -5,7 +5,7 @@ use std::{cmp, fmt, str};
 
 use bytes::Bytes;
 
-use super::{ErrorKind, InvalidUri, InvalidUriBytes, Port, URI_CHARS};
+use super::{ErrorKind, InvalidUri, Port, URI_CHARS};
 use crate::byte_str::ByteStr;
 
 /// Represents the authority component of a URI.
@@ -41,8 +41,8 @@ impl Authority {
     /// assert_eq!(authority.host(), "example.com");
     /// # }
     /// ```
-    pub(super) fn from_shared(s: Bytes) -> Result<Self, InvalidUriBytes> {
-        let authority_end = Authority::parse_non_empty(&s[..]).map_err(InvalidUriBytes)?;
+    pub(super) fn from_shared(s: Bytes) -> Result<Self, InvalidUri> {
+        let authority_end = Authority::parse_non_empty(&s[..])?;
 
         if authority_end != s.len() {
             return Err(ErrorKind::InvalidUriChar.into());
@@ -269,7 +269,7 @@ impl Authority {
 
 /*
 impl TryFrom<Bytes> for Authority {
-    type Error = InvalidUriBytes;
+    type Error = InvalidUri;
     /// Attempt to convert an `Authority` from `Bytes`.
     ///
     /// # Examples
@@ -290,7 +290,7 @@ impl TryFrom<Bytes> for Authority {
     /// # }
     /// ```
     fn try_from(s: Bytes) -> Result<Self, Self::Error> {
-        let authority_end = Authority::parse_non_empty(&s[..]).map_err(InvalidUriBytes)?;
+        let authority_end = Authority::parse_non_empty(&s[..])?;
 
         if authority_end != s.len() {
             return Err(ErrorKind::InvalidUriChar.into());

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -260,8 +260,54 @@ impl Uri {
     /// assert_eq!(uri.path(), "/foo");
     /// # }
     /// ```
-    pub fn from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
-        TryFrom::try_from(s)
+    fn from_shared(s: Bytes) -> Result<Uri, InvalidUriBytes> {
+        use self::ErrorKind::*;
+
+        if s.len() > MAX_LEN {
+            return Err(TooLong.into());
+        }
+
+        match s.len() {
+            0 => {
+                return Err(Empty.into());
+            }
+            1 => match s[0] {
+                b'/' => {
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: Authority::empty(),
+                        path_and_query: PathAndQuery::slash(),
+                    });
+                }
+                b'*' => {
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: Authority::empty(),
+                        path_and_query: PathAndQuery::star(),
+                    });
+                }
+                _ => {
+                    let authority = Authority::from_shared(s)?;
+
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: authority,
+                        path_and_query: PathAndQuery::empty(),
+                    });
+                }
+            },
+            _ => {}
+        }
+
+        if s[0] == b'/' {
+            return Ok(Uri {
+                scheme: Scheme::empty(),
+                authority: Authority::empty(),
+                path_and_query: PathAndQuery::from_shared(s)?,
+            });
+        }
+
+        parse_full(s)
     }
 
     /// Convert a `Uri` from a static string.
@@ -629,80 +675,6 @@ impl Uri {
 
     fn has_path(&self) -> bool {
         !self.path_and_query.data.is_empty() || !self.scheme.inner.is_none()
-    }
-}
-
-impl TryFrom<Bytes> for Uri {
-    type Error = InvalidUriBytes;
-
-    /// Attempt to convert a `Uri` from `Bytes`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate http;
-    /// # use http::uri::*;
-    /// extern crate bytes;
-    ///
-    /// use std::convert::TryFrom;
-    /// use bytes::Bytes;
-    ///
-    /// # pub fn main() {
-    /// let bytes = Bytes::from("http://example.com/foo");
-    /// let uri = Uri::try_from(bytes).unwrap();
-    ///
-    /// assert_eq!(uri.host().unwrap(), "example.com");
-    /// assert_eq!(uri.path(), "/foo");
-    /// # }
-    /// ```
-    fn try_from(s: Bytes) -> Result<Uri, Self::Error> {
-        use self::ErrorKind::*;
-
-        if s.len() > MAX_LEN {
-            return Err(TooLong.into());
-        }
-
-        match s.len() {
-            0 => {
-                return Err(Empty.into());
-            }
-            1 => match s[0] {
-                b'/' => {
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: Authority::empty(),
-                        path_and_query: PathAndQuery::slash(),
-                    });
-                }
-                b'*' => {
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: Authority::empty(),
-                        path_and_query: PathAndQuery::star(),
-                    });
-                }
-                _ => {
-                    let authority = Authority::from_shared(s)?;
-
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: authority,
-                        path_and_query: PathAndQuery::empty(),
-                    });
-                }
-            },
-            _ => {}
-        }
-
-        if s[0] == b'/' {
-            return Ok(Uri {
-                scheme: Scheme::empty(),
-                authority: Authority::empty(),
-                path_and_query: PathAndQuery::from_shared(s)?,
-            });
-        }
-
-        parse_full(s)
     }
 }
 

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -4,7 +4,7 @@ use std::{cmp, fmt, str};
 
 use bytes::Bytes;
 
-use super::{ErrorKind, InvalidUri, InvalidUriBytes};
+use super::{ErrorKind, InvalidUri};
 use crate::byte_str::ByteStr;
 
 /// Represents the path component of a URI
@@ -39,7 +39,7 @@ impl PathAndQuery {
     /// assert_eq!(path_and_query.query(), Some("world"));
     /// # }
     /// ```
-    pub(super) fn from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub(super) fn from_shared(mut src: Bytes) -> Result<Self, InvalidUri> {
         let mut query = NONE;
         let mut fragment = None;
 
@@ -281,7 +281,7 @@ impl<'a> TryFrom<&'a [u8]> for PathAndQuery {
     type Error = InvalidUri;
     #[inline]
     fn try_from(s: &'a [u8]) -> Result<Self, Self::Error> {
-        PathAndQuery::from_shared(Bytes::copy_from_slice(s)).map_err(|e| e.0)
+        PathAndQuery::from_shared(Bytes::copy_from_slice(s))
     }
 }
 

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -39,7 +39,7 @@ impl PathAndQuery {
     /// assert_eq!(path_and_query.query(), Some("world"));
     /// # }
     /// ```
-    pub fn from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
+    pub(super) fn from_shared(mut src: Bytes) -> Result<Self, InvalidUriBytes> {
         let mut query = NONE;
         let mut fragment = None;
 
@@ -275,20 +275,6 @@ impl PathAndQuery {
         }
         ret
     }
-
-    /// Converts this `PathAndQuery` back to a sequence of bytes
-    #[inline]
-    pub fn into_bytes(self) -> Bytes {
-        self.into()
-    }
-}
-
-impl TryFrom<Bytes> for PathAndQuery {
-    type Error = InvalidUriBytes;
-    #[inline]
-    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        PathAndQuery::from_shared(bytes)
-    }
 }
 
 impl<'a> TryFrom<&'a [u8]> for PathAndQuery {
@@ -312,12 +298,6 @@ impl FromStr for PathAndQuery {
     #[inline]
     fn from_str(s: &str) -> Result<Self, InvalidUri> {
         TryFrom::try_from(s)
-    }
-}
-
-impl From<PathAndQuery> for Bytes {
-    fn from(src: PathAndQuery) -> Bytes {
-        src.data.into()
     }
 }
 


### PR DESCRIPTION
This should remove `Bytes` from the public API while it is unstable, and adds `from_maybe_shared` generic constructors that can allow improved performance (less copies) if the correct version of `Bytes` is used.

Closes #366 