### PR TITLE
update suggested version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use `http`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-http = "0.1"
+http = "0.2"
 ```
 
 Next, add this to your crate:


### PR DESCRIPTION
looks like the version suggested in the readme was left at 0.1, making for a slightly confusing crates.io page