### PR TITLE
Remove obsolete `allow(warnings)` attributes

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -23,10 +23,6 @@ impl PathAndQuery {
         let mut fragment = None;
 
         // block for iterator borrow
-        //
-        // allow: `...` pattersn are now `..=`, but we cannot update yet
-        // because of minimum Rust version
-        #[allow(warnings)]
         {
             let mut iter = src.as_ref().iter().enumerate();
 
@@ -61,10 +57,6 @@ impl PathAndQuery {
 
             // query ...
             if query != NONE {
-
-                // allow: `...` pattersn are now `..=`, but we cannot update yet
-                // because of minimum Rust version
-                #[allow(warnings)]
                 for (i, &b) in iter {
                     match b {
                         // While queries *should* be percent-encoded, most


### PR DESCRIPTION
We were for a time allowing warnings on two sections of code due to
continued use of `...` pattern syntax.  We had deferred the change to
`..=` syntax so as to support earlier Rust versions.

However, in commit `6003c8eef9fd2e75668c88288462f8ca5d07389e` we
changed over to `..=` syntax.  The `allow(warnings)` attributes and
the related comments are now obsolete, and we remove them in this
commit.