### PR TITLE
feat: support conversions from `url::Url`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,15 @@ keywords = ["http"]
 categories = ["web-programming"]
 edition = "2018"
 
+[features]
+default = []
+url = ["url_2"]
+
 [dependencies]
 bytes = "0.5"
 fnv = "1.0.5"
 itoa = "0.4.1"
+url_2 = { package = "url", version = "2.1.0", optional = true }
 
 [dev-dependencies]
 indexmap = "1.0"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ fn main() {
 }
 ```
 
+`http` also supports conversions from
+[`url::Url`](https://github.com/servo/rust-url) using
+`std::convert::TryFrom`. To make use of this feature enable the `url`
+feature on `http`:
+
+```toml
+[dependencies]
+http = { version = "0.2", features = ["url"] }
+```
+
+Note that `http::Uri` is probably sufficient for most use-cases.
+
 # License
 
 Licensed under either of

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -723,6 +723,22 @@ impl<'a> TryFrom<&'a Uri> for Uri {
     }
 }
 
+#[cfg(feature = "url")]
+impl TryFrom<url_2::Url> for Uri {
+    type Error = InvalidUri;
+    fn try_from(url: url_2::Url) -> Result<Self, Self::Error> {
+        Uri::try_from(url.as_str())
+    }
+}
+
+#[cfg(feature = "url")]
+impl<'a> TryFrom<&'a url_2::Url> for Uri {
+    type Error = InvalidUri;
+    fn try_from(url: &'a url_2::Url) -> Result<Self, Self::Error> {
+        Uri::try_from(url.as_str())
+    }
+}
+
 /// Convert a `Uri` from parts
 ///
 /// # Examples

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -517,3 +517,17 @@ fn test_partial_eq_path_with_terminating_questionmark() {
 
     assert_eq!(uri, a);
 }
+
+#[cfg(feature = "url")]
+#[test]
+fn test_conversion_from_url() {
+    use std::convert::TryFrom;
+
+    let url = url_2::Url::parse(
+        "https://github.com/rust-lang/rust/issues?labels=E-easy&state=open"
+    ).unwrap();
+
+    let _ = Uri::try_from(&url).expect("Could not parse URI");
+    let _ = Uri::try_from(url).expect("Could not parse URI");
+}
+    


### PR DESCRIPTION
## Motivation

- A few AWS services (like SQS, IAM, EC2) use `application/x-www-form-urlencoded`-based RPC calls. While this encoding is typically handled by the SDKs, this code needs to exist somewhere.
- An off-by-default feature flag enabling a `TryFrom` conversion from `url::Url` allows for building complex queries using `url::Url`'s builder methods, but then converting to `http::Uri` at request construction time.
- Since all of `http`'s builders implement accept a `TryFrom<T>` (in `http::request::Builder`'s case, [a `Uri: TryFrom<T>`](https://docs.rs/http/0.2.0/http/request/struct.Builder.html#method.uri)), this feature allows for passing a `url::Url` into a request builder.