### PR TITLE
HeaderMap: Store pos and hash as u16

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -465,8 +465,6 @@ impl<T> HeaderMap<T> {
     /// assert_eq!(12, map.capacity());
     /// ```
     pub fn with_capacity(capacity: usize) -> HeaderMap<T> {
-        assert!(capacity <= MAX_SIZE, "requested capacity too large");
-
         if capacity == 0 {
             HeaderMap {
                 mask: 0,
@@ -477,6 +475,7 @@ impl<T> HeaderMap<T> {
             }
         } else {
             let raw_cap = to_raw_capacity(capacity).next_power_of_two();
+            assert!(raw_cap <= MAX_SIZE, "requested capacity too large");
             debug_assert!(raw_cap > 0);
 
             HeaderMap {
@@ -642,7 +641,7 @@ impl<T> HeaderMap<T> {
 
         if cap > self.indices.len() {
             let cap = cap.next_power_of_two();
-            assert!(cap < MAX_SIZE, "header map reserve over max capacity");
+            assert!(cap <= MAX_SIZE, "header map reserve over max capacity");
             assert!(cap != 0, "header map reserve overflowed");
 
             if self.entries.len() == 0 {
@@ -1543,6 +1542,7 @@ impl<T> HeaderMap<T> {
 
     #[inline]
     fn grow(&mut self, new_raw_cap: usize) {
+        assert!(new_raw_cap <= MAX_SIZE, "requested capacity too large");
         // This path can never be reached when handling the first allocation in
         // the map.
 
@@ -3109,6 +3109,7 @@ impl<T> ops::IndexMut<usize> for RawLinks<T> {
 impl Pos {
     #[inline]
     fn new(index: usize, hash: HashValue) -> Self {
+        debug_assert!(index < MAX_SIZE);
         Pos {
             index: index as Size,
             hash: hash,

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -44,6 +44,18 @@ fn reserve_over_capacity() {
 }
 
 #[test]
+fn with_capacity_max() {
+    // The largest capacity such that (cap + cap / 3) < MAX_SIZE.
+    HeaderMap::<u32>::with_capacity(24_576);
+}
+
+#[test]
+#[should_panic]
+fn with_capacity_overflow() {
+    HeaderMap::<u32>::with_capacity(24_577);
+}
+
+#[test]
 #[should_panic]
 fn reserve_overflow() {
     // See https://github.com/hyperium/http/issues/352


### PR DESCRIPTION
HeaderMap currently truncates all hashes to 16 bits, and limits its 
capacity to 32768 elements. The comments say this is done in order to store
positions and hashes as `u16`, to improve cache locality.  However, they are
currently stored as `usize`.  This branch changes the code to match the
comments.

This does not appear to cause any measurable improvement or regression in
speed in the HeaderMap benchmarks on my workstation. However, it should at
least reduce the memory footprint of every Headermap.