### PR TITLE
Remove unnecessary parentheses to fix warning

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -3192,7 +3192,7 @@ fn to_raw_capacity(n: usize) -> usize {
 
 #[inline]
 fn desired_pos(mask: Size, hash: HashValue) -> usize {
-    (hash.0 & mask)
+    hash.0 & mask
 }
 
 /// The number of steps that `current` is forward of the desired position for hash


### PR DESCRIPTION
This breaks nightly build in CI, see https://travis-ci.org/hyperium/http/jobs/641850080