### PR TITLE
Allow nightly build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 cache: cargo
 
 matrix:
+  allow_failures:
+    - rust: nightly
   include:
     - rust: stable
     - rust: beta


### PR DESCRIPTION
It's a common practice to allow failures in nightly for CI, as nightly is changing in a faster pace than most other projects, and it would be painful that you need to fix something whenever you want to change something.

This is especially a problem given that this project has `#[deny(warnings)]` which can be even more fluid.