### PR TITLE
WIP: Allow get user info from authority

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -39,6 +39,7 @@ pub use self::builder::Builder;
 pub use self::path::PathAndQuery;
 pub use self::port::Port;
 pub use self::scheme::Scheme;
+pub use self::userinfo::UserInfo;
 
 mod authority;
 mod builder;
@@ -47,6 +48,7 @@ mod port;
 mod scheme;
 #[cfg(test)]
 mod tests;
+mod userinfo;
 
 /// The URI component of a request.
 ///
@@ -143,6 +145,7 @@ enum ErrorKind {
 // u16::MAX is reserved for None
 const MAX_LEN: usize = (u16::MAX - 1) as usize;
 
+#[rustfmt::skip]
 const URI_CHARS: [u8; 256] = [
     //  0      1      2      3      4      5      6      7      8      9
         0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //   x

--- a/src/uri/userinfo.rs
+++ b/src/uri/userinfo.rs
@@ -1,0 +1,58 @@
+/// Represents the user info component of a URI.
+/// ```notrust
+/// abc://username:password@example.com:123/path/data?key=value&key2=value2#fragid1
+///       |---------------|
+///               |
+///           user info
+/// ```
+#[derive(Debug)]
+pub struct UserInfo<'a> {
+    username: Option<&'a str>,
+    password: Option<&'a str>,
+}
+
+impl<'a> UserInfo<'a> {
+    pub(crate) fn new(username: Option<&'a str>, password: Option<&'a str>) -> Self {
+        Self { username, password }
+    }
+
+    /// Get the username of this `UserInfo`.
+    /// ```notrust
+    /// abc://username:password@example.com:123/path/data?key=value&key2=value2#fragid1
+    ///       |------|
+    ///           |
+    ///       username
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let authority: Authority = "root@example.org:80".parse().unwrap();
+    ///
+    /// assert_eq!(authority.user_info().username(), Some("root"));
+    /// ```
+    pub fn username(&self) -> Option<&str> {
+        self.username
+    }
+
+    /// Get the password of this `Authority`.
+    /// ```notrust
+    /// abc://username:password@example.com:123/path/data?key=value&key2=value2#fragid1
+    ///                |------|
+    ///                    |
+    ///                password
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let authority: Authority = "root:mypassword@example.org:80".parse().unwrap();
+    ///
+    /// assert_eq!(authority.user_info().password(), Some("mypassword"));
+    /// ```
+    pub fn password(&self) -> Option<&str> {
+        self.password
+    }
+}


### PR DESCRIPTION
This PR provides ability to get username and password (userinfo) from `Authority`.

I proposed 3 ways:
1. two functions `username()` and `password()`
1. return  new struct `UserInfo<'a>` 
1. return tuple with 2 optional elements username and password.

Personally I would vote for 3 (Of course renamed to user_info). 

TODO:
* [ ] Chose method that should be implemented. user_info` `user_info2` or pair `username` and `password` and remove others.
* [ ] Add tests to choose method(s)
* [ ] Add notation to doc  about *strongly discourage any use* with reason that couldn't find in #12 