### PR TITLE
[src/error.rs] pub ErrorKind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.1"
 readme = "README.md"
 documentation = "https://docs.rs/http"
 repository = "https://github.com/hyperium/http"
-license = "MIT/Apache-2.0"
+license = "Apache-2.0 OR MIT"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Carl Lerche <me@carllerche.com>",

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub struct Error {
 /// A `Result` typedef to use with the `http::Error` type
 pub type Result<T> = result::Result<T, Error>;
 
-enum ErrorKind {
+pub enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),
     Uri(uri::InvalidUri),


### PR DESCRIPTION
I'm confused how to percolate errors from `http` through my library.

I want to percolate up a [`http::uri::ErrorKind::InvalidFormat`](https://github.com/hyperium/http/blob/c175fea/src/uri/mod.rs#L128-L141) if [`.host()`](https://github.com/hyperium/http/blob/c175fea/src/uri/mod.rs#L552-L555) is [`None`](https://doc.rust-lang.org/src/core/option.rs.html#159).