### PR TITLE
Audit the use of unsafe in uri/path.rs

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -518,6 +518,7 @@ mod tests {
         assert_eq!("a", pq_bytes(&[b'a']));
         assert_eq!("a?", pq_bytes(&[b'a', b'?']));
         assert_eq!("a?b", pq_bytes(&[b'a', b'?', b'b']));
+        assert_eq!("a?{b}", pq_bytes(&[b'a', b'?', b'{', b'b', b'}']));
         assert_eq!("a", pq_bytes(&[b'a', b'#', b'b']));
         assert_eq!("a?b", pq_bytes(&[b'a', b'?', b'b', b'#', b'c']));
 
@@ -530,6 +531,7 @@ mod tests {
     fn from_invalid_u8_slice_is_error() {
         assert!(is_invalid_pq_bytes(&[0xc0])); // invalid UTF-8
         assert!(is_invalid_pq_bytes(&[b' '])); // need percent encoding
+        assert!(is_invalid_pq_bytes(&[b'{'])); // need percent encoding
         assert!(is_invalid_pq_bytes(&[b'a', b'?', 0xc0])); // invalid UTF-8
         assert!(is_invalid_pq_bytes(&[b'a', b'?', b' '])); // needs percent encoding
     }

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -54,6 +54,9 @@ impl PathAndQuery {
                     0x7B |
                     0x7D if query.is_some() => Ok((query, i+1)),
 
+                    // all bytes 0x80 and above match here (among others)
+                    // so all Ok() returns in the other match arms identify
+                    // a single byte UTF-8 code point
                     _ => Err(InvalidUri(ErrorKind::InvalidUriChar)),
                 }
             })?;
@@ -61,6 +64,9 @@ impl PathAndQuery {
         src.truncate(len as usize);
 
         Ok(PathAndQuery {
+            // Safety: The try_fold() checks that each byte in the now truncated
+            // src is a single byte UTF-8 code point so src as a whole is valid
+            // UTF-8.
             data: unsafe { ByteStr::from_utf8_unchecked(src) },
             query: query.unwrap_or(NONE),
         })


### PR DESCRIPTION
Reorganize the one function with a use of unsafe (from_shared()) to highlight that it does a scan of each byte that it eventually passes to ByteStr::from_utf8_unchecked(). This makes it apparent (as described in the "Safety" comment) that the input to from_utf8_unchecked() is valid UTF-8 and is, thus, sound.

This is a part of #412. 