### PR TITLE
Audit use of unsafe in uri/authority.rs

### DIFF
--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -616,4 +616,14 @@ mod tests {
         let err = Authority::parse_non_empty(b"[fe80::1:2:3:4]%20").unwrap_err();
         assert_eq!(err.0, ErrorKind::InvalidAuthority);
     }
+
+    #[test]
+    fn rejects_invalid_utf8() {
+        let err = Authority::try_from([0xc0u8].as_ref()).unwrap_err();
+        assert_eq!(err.0, ErrorKind::InvalidUriChar);
+
+        let err = Authority::from_shared(Bytes::from_static([0xc0u8].as_ref()))
+            .unwrap_err();
+        assert_eq!(err.0, ErrorKind::InvalidUriChar);
+    }
 }

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -23,7 +23,7 @@ impl Authority {
 
     // Not public while `bytes` is unstable.
     pub(super) fn from_shared(s: Bytes) -> Result<Self, InvalidUri> {
-        // Preconditon on create_authority: trivially satisfied by the
+        // Precondition on create_authority: trivially satisfied by the
         // identity clousre
         create_authority(s, |s| s)
     }

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -530,6 +530,12 @@ mod tests {
     }
 
     #[test]
+    fn from_static_equates_with_a_str() {
+        let authority = Authority::from_static("example.com");
+        assert_eq!(authority, "example.com");
+    }
+
+    #[test]
     fn not_equal_with_a_str_of_a_different_authority() {
         let authority: Authority = "example.com".parse().unwrap();
         assert_ne!(&authority, "test.com");

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -143,6 +143,12 @@ enum ErrorKind {
 // u16::MAX is reserved for None
 const MAX_LEN: usize = (u16::MAX - 1) as usize;
 
+// URI_CHARS is a table of valid characters in a URI. An entry in the table is
+// 0 for invalid characters. For valid characters the entry is itself (i.e.
+// the entry for 33 is b'!' because b'!' == 33u8). An important characteristic
+// of this table is that all entries above 127 are invalid. This makes all of the
+// valid entries a valid single-byte UTF-8 code point. This means that a slice
+// of such valid entries is valid UTF-8.
 const URI_CHARS: [u8; 256] = [
     //  0      1      2      3      4      5      6      7      8      9
         0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //   x


### PR DESCRIPTION
Refactor the common code from three ways of creating an Authority into a private create_authority() function, which removes some code duplication (including duplicated uses of "unsafe"). Add comments describing the implicit preconditions and postconditions in create_authority() and the functions it calls which then make explicit the sound use of "unsafe" (as described in the "Safety" comment in create_authority().

This is part of #412.