### PR TITLE
Audit use of unsafe in uri/mod.rs

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -804,6 +804,8 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
             scheme.truncate(n);
 
             // Allocate the ByteStr
+            // Safety: the postcondition on Scheme2::parse() means that
+            // s[0..n+3] is valid UTF-8. scheme is a subslice of s[0..n+3].
             let val = unsafe { ByteStr::from_utf8_unchecked(scheme) };
 
             Scheme2::Other(Box::new(val))
@@ -828,6 +830,10 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
 
     let authority = s.split_to(authority_end);
     let authority = Authority {
+        // Safety: The postcondition on Authority::parse() means that
+        // s[0..authority_end] is valid UTF-8 after that call. The call
+        // to s.split_to() means that authority here is what s[0..authority_end]
+        // was after the call to Authority::parse().
         data: unsafe { ByteStr::from_utf8_unchecked(authority) },
     };
 

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -253,6 +253,7 @@ impl Scheme2<usize> {
         }
     }
 
+    // Postcondition: On Ok(Scheme2::Other(n)) return, s[0..n+3] is valid UTF-8
     pub(super) fn parse(s: &[u8]) -> Result<Scheme2<usize>, InvalidUri> {
         if s.len() >= 7 {
             // Check for HTTP
@@ -270,6 +271,9 @@ impl Scheme2<usize> {
         }
 
         if s.len() > 3 {
+            // The only Ok(Scheme2::Option(n)) return from this function is an
+            // early exit from this loop. This loop checks each byte in s against
+            // SCHEME_CHARS until until one of the early exit conditions.
             for i in 0..s.len() {
                 let b = s[i];
 
@@ -290,10 +294,15 @@ impl Scheme2<usize> {
                         }
 
                         // Return scheme
+                        // Postcondition: Every byte in s[0..i] has matched the
+                        // _ arm so is valid UTF-8. s[i..i+3] matches "://" which
+                        // is also valid UTF-8. Thus s[0..i+3] is valid UTF-8.
                         return Ok(Scheme2::Other(i));
                     }
                     // Invald scheme character, abort
                     0 => break,
+                    // Valid scheme character: imples that b is a valid, single
+                    // byte UTF-8 codepoint.
                     _ => {}
                 }
             }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -553,5 +553,6 @@ fn test_uri_from_u8_slice_error() {
     err(b"/?>");
 
     // invalid UTF-8
-    err(&[0xc0])
+    err(&[0xc0]);
+    err(&[b'h', b't', b't', b'p', b':', b'/', b'/', 0xc0]);
 }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -555,4 +555,14 @@ fn test_uri_from_u8_slice_error() {
     // invalid UTF-8
     err(&[0xc0]);
     err(&[b'h', b't', b't', b'p', b':', b'/', b'/', 0xc0]);
+    err(b"http://example.com/\0xc0");
+    err(b"http://example.com/path?\0xc0");
+}
+
+#[test]
+fn test_uri_with_invalid_fragment_is_valid() {
+    let uri_bytes = b"http://example.com/path?query#\0xc0";
+    let uri = Uri::try_from(uri_bytes.as_ref()).expect("conversion error");
+
+    assert_eq!(uri, "http://example.com/path?query");
 }


### PR DESCRIPTION
Added tests for attempts to parse various types of invalid `Uri`'s including ones with invalid UTF-8 bytes in them. Added a test for parsing `&[u8]` as a Uri where it has invalid UTF-8 bytes in the fragment. This test accepts the `Uri` as valid because `Uri` (currently) does not expose the fragment so those bytes are never interpreted as a `&str`.

Refactored the `parse_full()` function to eliminate some code duplication and thereby simplify the function. Finally, added comments to `parse_full()` and the functions it calls to document the postconditions that `parse_full()` relies on to make its use of `unsafe` sound.

This PR has a weak discrepancy on #414 and #416 in the sense that some of the comments added in this PR make more sense in light of the comments added in the earlier two PR's. There is no dependency in this PR on the earlier PR's to build or to run tests. 

This is a part of #412.