### PR TITLE
Audit the use of unsafe in header/value.rs

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -346,24 +346,18 @@ impl fmt::Debug for HeaderValue {
             f.write_str("\"")?;
             let bytes = self.as_bytes();
 
-            // Invariant1: bytes[range] is valid UTF-8 (for both instanses of range).
-            // Invariant2: In the try_fold() closure bytes[range.end] == b.
+            // Invariant: bytes[range] is valid UTF-8 (for both instanses of range).
             //
             // bytes[0..0] is empty so the starting value of range trivally satisfies
-            // the invariant 1. The first invocaton of the closure has range.end == 0
-            // and b == bytes[0], satisfying the second invariant.
-            //
-            // On the nth invocation of the closure b = bytes[range.end]. The end of
-            // range returned from the closure is range.end+1. On the n+1th invocation
-            // of the closure b will be the next byte of bytes which is bytes[range.end+1].
-            // The second invariant follows by induction.
-            let range = bytes.iter().try_fold(0..0, |range, &b| {
+            // the invariant.
+            let range = bytes.iter().try_fold(0..0, |range, _| {
+                let b = bytes[range.end];
                 if is_visible_ascii(b) && b != b'"' {
                     // Invariant: By the invariant bytes[range] is valid UTF-8.
-                    // bytes[range.end] == b and the postcondition on
-                    // is_visible_ascii() means that b (and hence bytes[range.end])
-                    // is valid, single-byte UTF-8 so bytes[range.start..range.end+1]
-                    // is valid UTF-8 and invariant 1 is satified.
+                    // The postcondition on is_visible_ascii() means that b (and
+                    // hence bytes[range.end]) is valid, single-byte UTF-8 so
+                    // bytes[range.start..range.end+1] is valid UTF-8 and the
+                    // invariant is satified.
                     Ok(range.start..range.end+1)
                 } else {
                     // Safety: By invariant 1 bytes[range] is valid UTF-8

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -166,6 +166,7 @@ impl HeaderValue {
     ///
     /// This function does NOT validate that illegal bytes are not contained
     /// within the buffer.
+    // TODO: Consider removing the 'unsafe' from this function.
     pub unsafe fn from_maybe_shared_unchecked<T>(src: T) -> HeaderValue
     where
         T: AsRef<[u8]> + 'static,

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -232,6 +232,9 @@ impl HeaderValue {
             }
         }
 
+        // Safety: the loop above checks that each byte is_valid_ascii() and
+        // the postcondtion on is_valid_ascii() implies that each byte is
+        // valid single-byte UTF-8.
         unsafe { Ok(str::from_utf8_unchecked(bytes)) }
     }
 
@@ -550,6 +553,8 @@ mod try_from_header_name_tests {
     }
 }
 
+// Postcondition: if the return is true then b is a visible ascii byte
+// which implies that it is a valid single-byte UTF-8 codepoint.
 fn is_visible_ascii(b: u8) -> bool {
     b >= 32 && b < 127 || b == b'\t'
 }


### PR DESCRIPTION
Reorganized the `Debug` impl for `HeaderValue` to make the invariants that its use of `unsafe` rely upon for soundness more obvious. This also adds a few more test cases for edges cases of the `Debug` impl. This also adds comments to all of the uses of `unsafe` in header/value.rs to explain and document their soundness.

One of the uses of `unsafe` in this file is in the function [`from_maybe_shared_unchecked()`](https://docs.rs/http/0.2.1/http/header/struct.HeaderValue.html#method.from_maybe_shared_unchecked) which is part of the public API of this crate. Currently this function is an `unsafe` function, but if `unsafe` functions are intended to signify caller responsibility for preventing undefined behaviour then this function is safe. There are no parameters you can pass to `from_maybe_shared_unchecked()` that will cause undefined behaviour.

There are, however, parameters you can pass to `from_maybe_shared_unchecked()` that would create a `HeaderValue` that did not comply with [RFC 7230 (section 3.2)](https://tools.ietf.org/html/rfc7230#section-3.2). That is, a `HeaderValue` that contained (for example) a NUL byte (0x00). If `unsafe` functions are intended to signify caller responsibility for maintaining some precondition (not just avoiding undefined behaviour) then it may make sense to keep `from_maybe_shared_unchecked()` as an `unsafe` function.

Removing `unsafe` from `from_maybe_shared_unchecked()` is an API change but it does not appear to be a breaking change.

Before this is merged we have to make a decision on the approach to `unsafe` functions to use and may further changes to `from_maybe_shared_unchecked()` (I can at least improve the doc comments if the `unsafe` should remain).

This is part of #412.