### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,11 +160,11 @@
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 #[macro_use]


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.