### PR TITLE
Correctly parse file URIs

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -802,10 +802,16 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
         }
         Scheme2::Other(n) => {
             // Grab the protocol
-            let mut scheme = s.split_to(n + 3);
+            let scheme = s.split_to(n);
 
-            // Strip ://, TODO: truncate
-            let _ = scheme.split_off(n);
+            // Remove ":" or "://" but not ":/"
+            if s[1] == b'/' && s[2] == b'/' {
+                // Remove "://"
+                let _ = s.split_to(3);
+            } else {
+                // Remove ":"
+                let _ = s.split_to(1);
+            }
 
             // Allocate the ByteStr
             let val = unsafe { ByteStr::from_utf8_unchecked(scheme) };
@@ -832,11 +838,6 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
             authority: authority,
             path_and_query: PathAndQuery::empty(),
         });
-    }
-
-    // Authority is required when absolute
-    if authority_end == 0 {
-        return Err(ErrorKind::InvalidFormat.into());
     }
 
     let authority = s.split_to(authority_end);
@@ -901,11 +902,13 @@ impl PartialEq<str> for Uri {
 
             other = &other[scheme.len()..];
 
-            if &other[..3] != b"://" {
+            if &other[..3] == b"://" {
+                other = &other[3..];
+            } else if &other[..1] == b":" {
+                other = &other[1..];
+            } else {
                 return false;
             }
-
-            other = &other[3..];
         }
 
         if let Some(auth) = self.authority() {

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -281,22 +281,22 @@ impl Scheme2<usize> {
             }
         }
 
-        if s.len() > 3 {
+        if s.len() >= 3 {
             for i in 0..s.len() {
                 let b = s[i];
 
                 match SCHEME_CHARS[b as usize] {
                     b':' => {
-                        // Not enough data remaining
-                        if s.len() < i + 3 {
+                        // According to https://tools.ietf.org/html/rfc3986#section-3 the URI "x:"
+                        // has scheme "x", but to differentiate from shortcuts like
+                        // "localhost:3000", which should be handled equivalent to
+                        // "http://localhost:3000" we only treat an URI part as a scheme if the ':'
+                        // is followed by a '/'.
+                        if (i + 1) >= s.len() || s[i + 1] != b'/' {
                             break;
                         }
 
-                        // Not a scheme
-                        if &s[i + 1..i + 3] != b"//" {
-                            break;
-                        }
-
+                        // Check length
                         if i > MAX_SCHEME_LEN {
                             return Err(ErrorKind::SchemeTooLong.into());
                         }
@@ -304,7 +304,7 @@ impl Scheme2<usize> {
                         // Return scheme
                         return Ok(Scheme2::Other(i));
                     }
-                    // Invald scheme character, abort
+                    // Invalid scheme character, abort
                     0 => break,
                     _ => {}
                 }

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -255,6 +255,34 @@ test_parse! {
 }
 
 test_parse! {
+    test_uri_parse_scheme_single_slash,
+    "x:/y",
+    [],
+
+    scheme = part!("x"),
+    path = "/y",
+}
+
+test_parse! {
+    test_uri_parse_scheme_triple_slash,
+    "x:///y",
+    [],
+
+    scheme = part!("x"),
+    path = "/y",
+}
+
+
+test_parse! {
+    test_uri_parse_scheme_file,
+    "file:/foo/bar",
+    ["file:///foo/bar"],
+
+    scheme = part!("file"),
+    path = "/foo/bar",
+}
+
+test_parse! {
     test_userinfo1,
     "http://a:b@127.0.0.1:1234/",
     [],
@@ -419,7 +447,6 @@ fn test_uri_parse_error() {
         Uri::from_str(s).unwrap_err();
     }
 
-    err("http://");
     err("htt:p//host");
     err("hyper.rs/");
     err("hyper.rs?key=val");


### PR DESCRIPTION
This changes the URI parser to allow URIs of the forms
* scheme:/absolute/path
* scheme:///absolute/path

It does impact HTTP URI parsing in that HTTP URIs without an authority
part are now allowed.

Fixes issue #323