### PR TITLE
feature: make possible to set port number in Uri::builder

### DIFF
--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -517,3 +517,37 @@ fn test_partial_eq_path_with_terminating_questionmark() {
 
     assert_eq!(uri, a);
 }
+
+#[test]
+fn test_uri_builder() {
+    assert_eq!(
+        "ws://localhost:8000/demo/",
+        Uri::builder()
+            .scheme("ws")
+            .authority("localhost")
+            .port(8000u16)
+            .path_and_query("/demo/")
+            .build()
+            .unwrap()
+    );
+
+    let uri = Uri::from_str("192.168.1.30:33").unwrap();
+    assert_eq!(33, uri.port().unwrap());
+    assert_eq!(
+        "ws://[2001:db8:1f70::999:de8:7648:6e8]:33/demo/",
+        Uri::builder()
+            .scheme("ws")
+            .authority("[2001:db8:1f70::999:de8:7648:6e8]")
+            .port(uri.port().unwrap())
+            .path_and_query("/demo/")
+            .build()
+            .unwrap()
+    );
+    Uri::builder()
+        .scheme("ws")
+        .authority("localhost:8000")
+        .port(8000u16)
+        .path_and_query("/demo/")
+        .build()
+        .unwrap_err();
+}


### PR DESCRIPTION
Make possible to set port number in `Uri::builder`.
I work with external API that gives me:
        - scheme;
        - hostname;
        - port;
        - path; 
It is inconvenient to use format/write macros instead of just call builder method.
ref #206