### PR TITLE
Fix the "Build Status" indicator in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A general purpose library of common HTTP types
 
-[![Build Status](https://travis-ci.org/hyperium/http.svg?branch=master)](https://travis-ci.org/hyperium/http)
+![Build Status](https://github.com/hyperium/http/workflows/CI/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/http.svg)](https://crates.io/crates/http)
 [![Documentation](https://docs.rs/http/badge.svg)][dox]
 


### PR DESCRIPTION
The "Build Status" markup badge had not been updated to reflect the
change of CI systems from TravisCI to GitHub Actions.

Note that I don't have any way of testing this, but I think this is correct.