### PR TITLE
Fix the build status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A general purpose library of common HTTP types
 
-![Build Status](https://github.com/hyperium/http/workflows/CI/badge.svg)
+[![CI](https://github.com/hyperium/http/workflows/CI/badge.svg)](https://github.com/hyperium/http/actions?query=workflow%3ACI)
 [![Crates.io](https://img.shields.io/crates/v/http.svg)](https://crates.io/crates/http)
 [![Documentation](https://docs.rs/http/badge.svg)][dox]
 


### PR DESCRIPTION
This change makes the alt tag for the badge image closer to what is
shown in the image itself (both are will show the name of the workflow:
CI) and makes the badge a link to the summary page for the CI workflow
in the GitHub Actions web interface.

Again I can't test this but I think it is correct (this time).