### PR TITLE
Clarify meaning of sensitive header values

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -304,9 +304,14 @@ impl HeaderValue {
     /// Returns `true` if the value represents sensitive data.
     ///
     /// Sensitive data could represent passwords or other data that should not
-    /// be stored on disk or in memory. This setting can be used by components
-    /// like caches to avoid storing the value. HPACK encoders must set the
-    /// header field to never index when `is_sensitive` returns true.
+    /// be stored on disk or in memory. By marking header values as sensitive,
+    /// components using this crate can be instructed to treat them with special
+    /// care for security reasons. For example, caches can avoid storing
+    /// sensitive values, and HPACK encoders used by HTTP/2.0 implementations
+    /// can choose not to compress them.
+    ///
+    /// Additionally, sensitive values will be masked by the `Debug`
+    /// implementation of `HeaderValue`.
     ///
     /// Note that sensitivity is not factored into equality or ordering.
     ///


### PR DESCRIPTION
While the documentation mentions that header values can be marked as sensitive in order to inform outside components that these header values may require special treatment, it was unclear to me whether doing that affects the behavior of this crate.

In fact, the only place in this crate that makes a distinction between regular and sensitive header values is the `Debug` trait implementation of `HeaderValue`, which masks sensitive values in the output.

This adds a short note to the documentation to clarify this and to avoid that users think that there might be, for example, a security benefit on the protocol level.