### PR TITLE
Audit use of unsafe in header/name.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ seahash = "3.0.5"
 serde = "1.0"
 serde_json = "1.0"
 doc-comment = "0.3"
+criterion = "0.3.2"
 
 [[bench]]
 name = "header_map"
@@ -42,6 +43,11 @@ path = "benches/header_map/mod.rs"
 [[bench]]
 name = "header_name"
 path = "benches/header_name.rs"
+
+[[bench]]
+name = "header_name2"
+path = "benches/header_name2.rs"
+harness = false
 
 [[bench]]
 name = "header_value"

--- a/benches/header_name2.rs
+++ b/benches/header_name2.rs
@@ -1,0 +1,52 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId,Criterion, Throughput};
+use http::header::HeaderName;
+
+// This is a list of some of the standard headers ordered by increasing size.
+// It has exactly one standard header per size (some sizes don't have a standard
+// header).
+const STANDARD_HEADERS_BY_SIZE: &[&str] = &[
+    "te",
+    "age",
+    "date",
+    "allow",
+    "accept",
+    "alt-svc",
+    "if-match",
+    "forwarded",
+    "connection",
+    "retry-after",
+    "content-type",
+    "accept-ranges",
+    "accept-charset",
+    "accept-encoding",
+    "content-encoding",
+    "if-modified-since",
+    "proxy-authenticate",
+    "content-disposition",
+    "sec-websocket-accept",
+    "sec-websocket-version",
+    "access-control-max-age",
+    "content-security-policy",
+    "sec-websocket-extensions",
+    "strict-transport-security",
+    "access-control-allow-origin",
+    "access-control-allow-headers",
+    "access-control-expose-headers",
+    "access-control-request-headers",
+    "access-control-allow-credentials",
+    "content-security-policy-report-only",
+];
+
+fn header_name_by_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("std_hdr");
+    for name in STANDARD_HEADERS_BY_SIZE {
+        group.throughput(Throughput::Bytes(name.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), name, |b, name| {
+            b.iter(|| HeaderName::from_static(name) );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, header_name_by_size);
+criterion_main!(benches);

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1046,7 +1046,7 @@ macro_rules! eq {
         $($cmp) && *
     };
     (($($cmp:expr,)*) $v:ident[$n:expr] == $a:tt $($rest:tt)*) => {
-        eq!(($($cmp,)* unsafe {*($v[$n].as_ptr())} == $a,) $v[$n+1] == $($rest)*)
+        eq!(($($cmp,)* unsafe {assume_init_eq($v[$n], $a)} ,) $v[$n+1] == $($rest)*)
     };
     ($v:ident == $($rest:tt)+) => {
         eq!(() $v[0] == $($rest)+)
@@ -1080,41 +1080,41 @@ fn parse_hdr<'a>(
 
 
     macro_rules! to_lower {
-        ($d:ident, $src:ident, 1) => { unsafe {*($d[0].as_mut_ptr()) = table[$src[0] as usize];} };
-        ($d:ident, $src:ident, 2) => { to_lower!($d, $src, 1); unsafe {*($d[1].as_mut_ptr())  = table[$src[1] as usize];} };
-        ($d:ident, $src:ident, 3) => { to_lower!($d, $src, 2); unsafe {*($d[2].as_mut_ptr())  = table[$src[2] as usize];} };
-        ($d:ident, $src:ident, 4) => { to_lower!($d, $src, 3); unsafe {*($d[3].as_mut_ptr())  = table[$src[3] as usize];} };
-        ($d:ident, $src:ident, 5) => { to_lower!($d, $src, 4); unsafe {*($d[4].as_mut_ptr())  = table[$src[4] as usize];} };
-        ($d:ident, $src:ident, 6) => { to_lower!($d, $src, 5); unsafe {*($d[5].as_mut_ptr())  = table[$src[5] as usize];} };
-        ($d:ident, $src:ident, 7) => { to_lower!($d, $src, 6); unsafe {*($d[6].as_mut_ptr())  = table[$src[6] as usize];} };
-        ($d:ident, $src:ident, 8) => { to_lower!($d, $src, 7); unsafe {*($d[7].as_mut_ptr())  = table[$src[7] as usize];} };
-        ($d:ident, $src:ident, 9) => { to_lower!($d, $src, 8); unsafe {*($d[8].as_mut_ptr())  = table[$src[8] as usize];} };
-        ($d:ident, $src:ident, 10) => { to_lower!($d, $src, 9); unsafe {*($d[9].as_mut_ptr())  = table[$src[9] as usize];} };
-        ($d:ident, $src:ident, 11) => { to_lower!($d, $src, 10); unsafe {*($d[10].as_mut_ptr())  = table[$src[10] as usize];} };
-        ($d:ident, $src:ident, 12) => { to_lower!($d, $src, 11); unsafe {*($d[11].as_mut_ptr())  = table[$src[11] as usize];} };
-        ($d:ident, $src:ident, 13) => { to_lower!($d, $src, 12); unsafe {*($d[12].as_mut_ptr())  = table[$src[12] as usize];} };
-        ($d:ident, $src:ident, 14) => { to_lower!($d, $src, 13); unsafe {*($d[13].as_mut_ptr())  = table[$src[13] as usize];} };
-        ($d:ident, $src:ident, 15) => { to_lower!($d, $src, 14); unsafe {*($d[14].as_mut_ptr())  = table[$src[14] as usize];} };
-        ($d:ident, $src:ident, 16) => { to_lower!($d, $src, 15); unsafe {*($d[15].as_mut_ptr())  = table[$src[15] as usize];} };
-        ($d:ident, $src:ident, 17) => { to_lower!($d, $src, 16); unsafe {*($d[16].as_mut_ptr())  = table[$src[16] as usize];} };
-        ($d:ident, $src:ident, 18) => { to_lower!($d, $src, 17); unsafe {*($d[17].as_mut_ptr())  = table[$src[17] as usize];} };
-        ($d:ident, $src:ident, 19) => { to_lower!($d, $src, 18); unsafe {*($d[18].as_mut_ptr())  = table[$src[18] as usize];} };
-        ($d:ident, $src:ident, 20) => { to_lower!($d, $src, 19); unsafe {*($d[19].as_mut_ptr())  = table[$src[19] as usize];} };
-        ($d:ident, $src:ident, 21) => { to_lower!($d, $src, 20); unsafe {*($d[20].as_mut_ptr())  = table[$src[20] as usize];} };
-        ($d:ident, $src:ident, 22) => { to_lower!($d, $src, 21); unsafe {*($d[21].as_mut_ptr())  = table[$src[21] as usize];} };
-        ($d:ident, $src:ident, 23) => { to_lower!($d, $src, 22); unsafe {*($d[22].as_mut_ptr())  = table[$src[22] as usize];} };
-        ($d:ident, $src:ident, 24) => { to_lower!($d, $src, 23); unsafe {*($d[23].as_mut_ptr())  = table[$src[23] as usize];} };
-        ($d:ident, $src:ident, 25) => { to_lower!($d, $src, 24); unsafe {*($d[24].as_mut_ptr())  = table[$src[24] as usize];} };
-        ($d:ident, $src:ident, 26) => { to_lower!($d, $src, 25); unsafe {*($d[25].as_mut_ptr())  = table[$src[25] as usize];} };
-        ($d:ident, $src:ident, 27) => { to_lower!($d, $src, 26); unsafe {*($d[26].as_mut_ptr())  = table[$src[26] as usize];} };
-        ($d:ident, $src:ident, 28) => { to_lower!($d, $src, 27); unsafe {*($d[27].as_mut_ptr())  = table[$src[27] as usize];} };
-        ($d:ident, $src:ident, 29) => { to_lower!($d, $src, 28); unsafe {*($d[28].as_mut_ptr())  = table[$src[28] as usize];} };
-        ($d:ident, $src:ident, 30) => { to_lower!($d, $src, 29); unsafe {*($d[29].as_mut_ptr())  = table[$src[29] as usize];} };
-        ($d:ident, $src:ident, 31) => { to_lower!($d, $src, 30); unsafe {*($d[30].as_mut_ptr())  = table[$src[30] as usize];} };
-        ($d:ident, $src:ident, 32) => { to_lower!($d, $src, 31); unsafe {*($d[31].as_mut_ptr())  = table[$src[31] as usize];} };
-        ($d:ident, $src:ident, 33) => { to_lower!($d, $src, 32); unsafe {*($d[32].as_mut_ptr())  = table[$src[32] as usize];} };
-        ($d:ident, $src:ident, 34) => { to_lower!($d, $src, 33); unsafe {*($d[33].as_mut_ptr())  = table[$src[33] as usize];} };
-        ($d:ident, $src:ident, 35) => { to_lower!($d, $src, 34); unsafe {*($d[34].as_mut_ptr())  = table[$src[34] as usize];} };
+        ($d:ident, $src:ident, 1) => { $d[0] = MaybeUninit::new(table[$src[0] as usize]); };
+        ($d:ident, $src:ident, 2) => { to_lower!($d, $src, 1); $d[1] = MaybeUninit::new(table[$src[1] as usize]); };
+        ($d:ident, $src:ident, 3) => { to_lower!($d, $src, 2); $d[2] = MaybeUninit::new(table[$src[2] as usize]); };
+        ($d:ident, $src:ident, 4) => { to_lower!($d, $src, 3); $d[3] = MaybeUninit::new(table[$src[3] as usize]); };
+        ($d:ident, $src:ident, 5) => { to_lower!($d, $src, 4); $d[4] = MaybeUninit::new(table[$src[4] as usize]); };
+        ($d:ident, $src:ident, 6) => { to_lower!($d, $src, 5); $d[5] = MaybeUninit::new(table[$src[5] as usize]); };
+        ($d:ident, $src:ident, 7) => { to_lower!($d, $src, 6); $d[6] = MaybeUninit::new(table[$src[6] as usize]); };
+        ($d:ident, $src:ident, 8) => { to_lower!($d, $src, 7); $d[7] = MaybeUninit::new(table[$src[7] as usize]); };
+        ($d:ident, $src:ident, 9) => { to_lower!($d, $src, 8); $d[8] = MaybeUninit::new(table[$src[8] as usize]); };
+        ($d:ident, $src:ident, 10) => { to_lower!($d, $src, 9); $d[9] = MaybeUninit::new(table[$src[9] as usize]); };
+        ($d:ident, $src:ident, 11) => { to_lower!($d, $src, 10); $d[10] = MaybeUninit::new(table[$src[10] as usize]); };
+        ($d:ident, $src:ident, 12) => { to_lower!($d, $src, 11); $d[11] = MaybeUninit::new(table[$src[11] as usize]); };
+        ($d:ident, $src:ident, 13) => { to_lower!($d, $src, 12); $d[12] = MaybeUninit::new(table[$src[12] as usize]); };
+        ($d:ident, $src:ident, 14) => { to_lower!($d, $src, 13); $d[13] = MaybeUninit::new(table[$src[13] as usize]); };
+        ($d:ident, $src:ident, 15) => { to_lower!($d, $src, 14); $d[14] = MaybeUninit::new(table[$src[14] as usize]); };
+        ($d:ident, $src:ident, 16) => { to_lower!($d, $src, 15); $d[15] = MaybeUninit::new(table[$src[15] as usize]); };
+        ($d:ident, $src:ident, 17) => { to_lower!($d, $src, 16); $d[16] = MaybeUninit::new(table[$src[16] as usize]); };
+        ($d:ident, $src:ident, 18) => { to_lower!($d, $src, 17); $d[17] = MaybeUninit::new(table[$src[17] as usize]); };
+        ($d:ident, $src:ident, 19) => { to_lower!($d, $src, 18); $d[18] = MaybeUninit::new(table[$src[18] as usize]); };
+        ($d:ident, $src:ident, 20) => { to_lower!($d, $src, 19); $d[19] = MaybeUninit::new(table[$src[19] as usize]); };
+        ($d:ident, $src:ident, 21) => { to_lower!($d, $src, 20); $d[20] = MaybeUninit::new(table[$src[20] as usize]); };
+        ($d:ident, $src:ident, 22) => { to_lower!($d, $src, 21); $d[21] = MaybeUninit::new(table[$src[21] as usize]); };
+        ($d:ident, $src:ident, 23) => { to_lower!($d, $src, 22); $d[22] = MaybeUninit::new(table[$src[22] as usize]); };
+        ($d:ident, $src:ident, 24) => { to_lower!($d, $src, 23); $d[23] = MaybeUninit::new(table[$src[23] as usize]); };
+        ($d:ident, $src:ident, 25) => { to_lower!($d, $src, 24); $d[24] = MaybeUninit::new(table[$src[24] as usize]); };
+        ($d:ident, $src:ident, 26) => { to_lower!($d, $src, 25); $d[25] = MaybeUninit::new(table[$src[25] as usize]); };
+        ($d:ident, $src:ident, 27) => { to_lower!($d, $src, 26); $d[26] = MaybeUninit::new(table[$src[26] as usize]); };
+        ($d:ident, $src:ident, 28) => { to_lower!($d, $src, 27); $d[27] = MaybeUninit::new(table[$src[27] as usize]); };
+        ($d:ident, $src:ident, 29) => { to_lower!($d, $src, 28); $d[28] = MaybeUninit::new(table[$src[28] as usize]); };
+        ($d:ident, $src:ident, 30) => { to_lower!($d, $src, 29); $d[29] = MaybeUninit::new(table[$src[29] as usize]); };
+        ($d:ident, $src:ident, 31) => { to_lower!($d, $src, 30); $d[30] = MaybeUninit::new(table[$src[30] as usize]); };
+        ($d:ident, $src:ident, 32) => { to_lower!($d, $src, 31); $d[31] = MaybeUninit::new(table[$src[31] as usize]); };
+        ($d:ident, $src:ident, 33) => { to_lower!($d, $src, 32); $d[32] = MaybeUninit::new(table[$src[32] as usize]); };
+        ($d:ident, $src:ident, 34) => { to_lower!($d, $src, 33); $d[33] = MaybeUninit::new(table[$src[33] as usize]); };
+        ($d:ident, $src:ident, 35) => { to_lower!($d, $src, 34); $d[34] = MaybeUninit::new(table[$src[34] as usize]); };
     }
 
     assert!(len < super::MAX_HEADER_NAME_LEN,
@@ -1188,7 +1188,7 @@ fn parse_hdr<'a>(
                 return Ok(Origin.into());
             } else if eq!(b == b'p' b'r' b'a' b'g' b'm' b'a') {
                 return Ok(Pragma.into());
-            } else if unsafe {*(b[0].as_ptr())} == b's' {
+            } else if unsafe {assume_init_eq(b[0], b's')} {
                 if eq!(b[1] == b'e' b'r' b'v' b'e' b'r') {
                     return Ok(Server.into());
                 }
@@ -1277,13 +1277,13 @@ fn parse_hdr<'a>(
         13 => {
             to_lower!(b, data, 13);
 
-            if unsafe {*(b[0].as_ptr())} == b'a' {
+            if unsafe {assume_init_eq(b[0], b'a')} {
                 if eq!(b[1] == b'c' b'c' b'e' b'p' b't' b'-' b'r' b'a' b'n' b'g' b'e' b's') {
                     return Ok(AcceptRanges.into());
                 } else if eq!(b[1] == b'u' b't' b'h' b'o' b'r' b'i' b'z' b'a' b't' b'i' b'o' b'n') {
                     return Ok(Authorization.into());
                 }
-            } else if unsafe {*(b[0].as_ptr())} == b'c' {
+            } else if unsafe {assume_init_eq(b[0], b'c')} {
                 if eq!(b[1] == b'a' b'c' b'h' b'e' b'-' b'c' b'o' b'n' b't' b'r' b'o' b'l') {
                     return Ok(CacheControl.into());
                 } else if eq!(b[1] == b'o' b'n' b't' b'e' b'n' b't' b'-' b'r' b'a' b'n' b'g' b'e' )
@@ -1513,7 +1513,7 @@ fn parse_hdr<'a>(
         _ => {
             if len < 64 {
                 for i in 0..len {
-                    unsafe {*(b[i].as_mut_ptr()) = table[data[i] as usize]; }
+                    b[i] = MaybeUninit::new(table[data[i] as usize]);
                 }
 
                 validate(&b[..len])
@@ -1555,7 +1555,7 @@ fn parse_hdr<'a>(
         len if len > 64 => Ok(HdrName::custom(data, false)),
         len => {
             // Read from data into the buffer - transforming using `table` as we go
-            data.iter().zip(b.iter_mut()).for_each(|(index, out)| unsafe {*(out.as_mut_ptr()) = table[*index as usize]});
+            data.iter().zip(b.iter_mut()).for_each(|(index, out)| *out = MaybeUninit::new(table[*index as usize]));
             let b = unsafe {slice_assume_init(&b[..len])};
             match &b[0..len] {
                 b"te" => Ok(Te.into()),
@@ -2129,15 +2129,32 @@ fn eq_ignore_ascii_case(lower: &[u8], s: &[u8]) -> bool {
     })
 }
 
+// Utility functions for MaybeUninit<>. These are drawn from unstable API's on 
+// MaybeUninit<> itself.
 const SCRATCH_BUF_SIZE: usize = 64;
 
 fn uninit_u8_array() -> [MaybeUninit<u8>; SCRATCH_BUF_SIZE] {
-        unsafe { MaybeUninit::<[MaybeUninit<u8>; SCRATCH_BUF_SIZE]>::uninit().assume_init() }
+    let arr = MaybeUninit::<[MaybeUninit<u8>; SCRATCH_BUF_SIZE]>::uninit();
+    // Safety: assume_init() is claiming that an array of MaybeUninit<> 
+    // has been initilized, but MaybeUninit<>'s do not require initilizaton.
+    unsafe { arr.assume_init() }
 }
 
+// Assuming all the elements are initilized, get a slice of them.
+//
+// Safety: All elements of `slice` must be initilized to prevent
+// undefined behavior.
 unsafe fn slice_assume_init<T>(slice: &[MaybeUninit<T>]) -> &[T] {
         &*(slice as *const [MaybeUninit<T>] as *const [T])
-    }
+}
+
+// Compare `rhs` to `lhs` assuming the latter is initilized.
+//
+// Safety: `lhs` must be initilized to avoid undefined behavior.
+#[cfg(any(not(debug_assertions), not(target_arch = "wasm32")))]
+unsafe fn assume_init_eq<T: PartialEq>(lhs: MaybeUninit<T>, rhs: T) -> bool {
+    *(lhs.as_ptr()) == rhs
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1359,7 +1359,7 @@ fn parse_hdr<'a>(
             // Precondition: The post-condition on to_lower!() ensures the first 15 
             // bytes of b are intitialized so, in particular the first 7 are.
             if eq!(b == b'a' b'c' b'c' b'e' b'p' b't' b'-') { // accept-
-                // Precondition: The first 15 bytes of 5 are intitialized so the
+                // Precondition: The first 15 bytes of b are intitialized so the
                 // first 8 starting at b[7] are.
                 if eq!(b[7] == b'e' b'n' b'c' b'o' b'd' b'i' b'n' b'g') {
                     return Ok(AcceptEncoding.into())

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1041,22 +1041,6 @@ const HEADER_CHARS_H2: [u8; 256] = [
 ];
 
 #[cfg(any(not(debug_assertions), not(target_arch = "wasm32")))]
-macro_rules! eq {
-    (($($cmp:expr,)*) $v:ident[$n:expr] ==) => {
-        $($cmp) && *
-    };
-    (($($cmp:expr,)*) $v:ident[$n:expr] == $a:tt $($rest:tt)*) => {
-        eq!(($($cmp,)* unsafe {*($v[$n].as_ptr())} == $a ,) $v[$n+1] == $($rest)*)
-    };
-    ($v:ident == $($rest:tt)+) => {
-        eq!(() $v[0] == $($rest)+)
-    };
-    ($v:ident[$n:expr] == $($rest:tt)+) => {
-        eq!(() $v[$n] == $($rest)+)
-    };
-}
-
-#[cfg(any(not(debug_assertions), not(target_arch = "wasm32")))]
 /// This version is best under optimized mode, however in a wasm debug compile,
 /// the `eq` macro expands to 1 + 1 + 1 + 1... and wasm explodes when this chain gets too long
 /// See https://github.com/DenisKolodin/yew/issues/478
@@ -1077,6 +1061,21 @@ fn parse_hdr<'a>(
             Ok(HdrName::custom(buf, true))
         }
     };
+
+    macro_rules! eq {
+        (($($cmp:expr,)*) $v:ident[$n:expr] ==) => {
+            $($cmp) && *
+        };
+        (($($cmp:expr,)*) $v:ident[$n:expr] == $a:tt $($rest:tt)*) => {
+            eq!(($($cmp,)* unsafe {*($v[$n].as_ptr())} == $a ,) $v[$n+1] == $($rest)*)
+        };
+        ($v:ident == $($rest:tt)+) => {
+            eq!(() $v[0] == $($rest)+)
+        };
+        ($v:ident[$n:expr] == $($rest:tt)+) => {
+            eq!(() $v[$n] == $($rest)+)
+        };
+    }
 
 
     macro_rules! to_lower {


### PR DESCRIPTION
This PR documents and improves the use of `unsafe` in the `header::name` module. That module has two kinds of usages of `unsafe`: the use of uninitialized memory and calls to `ByteStr::from_utf8_unchecked()`.

The uninitialized memory in `header::name` is used as a temporary buffer when normalizing the bytes that represent a name before matching them against the standard header names. This PR upgrades the uninitialized memory from the deprecated  [`mem::unititialized()`](https://doc.rust-lang.org/stable/std/mem/fn.uninitialized.html) to an array of [`MaybeUninit<u8>` ](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html). This upgrade has the useful side effect of mostly localizing the use of `unsafe` related to uninitialized memory to the two implementations of `parse_hdr()`.  

The PR documents (through comments) the preconditions and post-conditions that make the use of uninitialized memory sound. The performance sensitive nature of `parse_hdr()` make these comments harder to follow than they might have been had it been possible to refactor parse_hdr() without causing a performance regression (I started such a refactoring but backed off when it caused regressions). The documented preconditions and post-conditions show the reasoning on how each `MaybeUninit<u8>` is initialized before it is accessed for reading and before it is used as a part of the return from `parse_hdr()`.

The PR also document the preconditions, post-conditions, and invariant that make the use of `unsafe` related to `ByteStr::from_utf8_unchecked` sound. These comments are also more extensive than they might have been because of the performance sensitive nature of `parse_hdr()`.

Finally the PR adds a new set of micro-benchmarks related to parsing the standard header names.

The new benchmarks make use of the [criterion](https://crates.io/crates/criterion) micro-benchmarking framework. This adds a new dev-dependency which is a major downside of this change. I suggest, though, that this downside is offset by the following upsides:
- criterion allows for running benchmarks on stable
- criterion makes it easy to run performance comparisons with either the last benchmark run or with a named baseline (and reports statistically significant improvements or regressions)
- criterion allows for more reliable benchmarks because of its separate warmup and measuring phases
- criterion is a well written, well designed, and actively maintained crate

This is part of #412.