### PR TITLE
Return an error rather than panicking when HeaderName is too long

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -169,4 +169,4 @@ pub use self::name::{
 /// Generally, 64kb for a header name is WAY too much than would ever be needed
 /// in practice. Restricting it to this size enables using `u16` values to
 /// represent offsets when dealing with header names.
-const MAX_HEADER_NAME_LEN: usize = 1 << 16;
+const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1116,10 +1116,6 @@ fn parse_hdr<'a>(
         ($d:ident, $src:ident, 35) => { to_lower!($d, $src, 34); $d[34] = table[$src[34] as usize]; };
     }
 
-    assert!(len < super::MAX_HEADER_NAME_LEN,
-            "header name too long -- max length is {}",
-            super::MAX_HEADER_NAME_LEN);
-
     match len {
         0 => Err(InvalidHeaderName::new()),
         2 => {
@@ -1509,17 +1505,16 @@ fn parse_hdr<'a>(
                 validate(b, len)
             }
         }
-        _ => {
-            if len < 64 {
-                for i in 0..len {
-                    b[i] = table[data[i] as usize];
-                }
-
-                validate(b, len)
-            } else {
-                Ok(HdrName::custom(data, false))
+        len if len < 64 => {
+            for i in 0..len {
+                b[i] = table[data[i] as usize];
             }
+            validate(b, len)
         }
+        len if len <= super::MAX_HEADER_NAME_LEN => {
+            Ok(HdrName::custom(data, false))
+        }
+        _ => Err(InvalidHeaderName::new()),
     }
 }
 
@@ -2154,6 +2149,24 @@ mod tests {
             let hdr = vec![1u8; i];
             assert!(HeaderName::from_bytes(&hdr).is_err(), "{} invalid header chars did not fail", i);
         }
+    }
+
+    #[test]
+    fn test_invalid_name_lengths() {
+        assert!(
+            HeaderName::from_bytes(&[]).is_err(),
+            "zero-length header name is an error",
+        );
+        let mut long = vec![b'a'; super::super::MAX_HEADER_NAME_LEN];
+        assert!(
+            HeaderName::from_bytes(long.as_slice()).is_ok(),
+            "max header name length is ok",
+        );
+        long.push(b'a');
+        assert!(
+            HeaderName::from_bytes(long.as_slice()).is_err(),
+            "longer than max header name length is an error",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #432.

This eliminates an undocumented panic from the `HeaderName` creation functions, returning instead an `InvalidHeaderName` when the name length exceeds `MAX_HEADER_NAME_LEN`.

I considered making `InvalidHeaderName` a richer error type, but since it was already used for another type of length error (rejecting zero-length names) I figured it was okay to reuse.

I also redefined `MAX_HEADER_NAME_LEN` slightly, so that it is equal to the largest allowed header length, rather than one past that value. This was motivated by discovering a bug in my comparison logic when I went to write the new test exercising the wrong-length error conditions.