### PR TITLE
Make StatusCode::as_str return 'static str

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -125,7 +125,7 @@ impl StatusCode {
     /// assert_eq!(status.as_str(), "200");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         CODES_AS_STR[(self.0 - 100) as usize]
     }
 


### PR DESCRIPTION
In the current version the lifetime is tied to self which is needlessly
restrictive as the strings are in fact static.