### PR TITLE
Implement a non-failing Response Builder.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -205,6 +205,10 @@ pub struct Parts {
 ///
 /// This type can be used to construct an instance of `Response` through a
 /// builder-like pattern.
+/// This builder can represent an erroneous state, so finalizing
+/// it (with the `.body` method) may return an error.
+///
+/// See also [`Builder2`](struct.Builder2.html).
 #[derive(Debug)]
 pub struct Builder {
     inner: Result<Parts>,
@@ -215,7 +219,13 @@ pub struct Builder {
 /// This type can be used to construct an instance of `Response` through a
 /// builder-like pattern.
 ///
-/// This variant avoids error states.
+/// This builder can not represent an erroneous state, so as long
+/// as you have a `Builder2` you can get a `Response`.
+/// Most methods on this builder is guaranteed to return a builder.
+/// The exception, `try_header()`, is explicit by returning a
+/// `Result<Builder2>`.
+///
+/// See also [`Builder`](struct.Builder.html).
 #[derive(Debug)]
 pub struct Builder2 {
     inner: Parts,
@@ -225,7 +235,11 @@ impl Response<()> {
     /// Creates a new builder-style object to manufacture a `Response`
     ///
     /// This method returns an instance of `Builder` which can be used to
-    /// create a `Response`.
+    /// create a `Result<Response>`.
+    /// This builder can represent an erroneous state, so finalizing
+    /// it (with the `.body` method) may return an error.
+    ///
+    /// See also [`builder2`](#method.builder2).
     ///
     /// # Examples
     ///
@@ -246,6 +260,10 @@ impl Response<()> {
     ///
     /// This method returns an instance of `Builder` which can be used to
     /// create a `Response`.
+    /// This builder can not represent an erroneous state, so as long
+    /// as you have a `Builder2` you can get a `Response`.
+    ///
+    /// See also [`builder`](#method.builder).
     ///
     /// # Examples
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -208,9 +208,12 @@ pub struct Parts {
 /// This builder can represent an erroneous state, so finalizing
 /// it (with the `.body` method) may return an error.
 ///
-/// See also [`Builder2`](struct.Builder2.html).
+/// See also [`Builder2`].
 #[derive(Debug)]
-#[deprecated(note = "Please use Self::builder2, it will replace Builder")]
+// Note: rustc 1.39.0 does some use I can't find, so I can't deprecate
+// the type.  Instead, I have just deprecated every function that
+// returns or consumes a Builder.
+//#[deprecated(note = "Please use Builder2, it will replace Builder")]
 pub struct Builder {
     inner: Result<Parts>,
 }
@@ -226,7 +229,7 @@ pub struct Builder {
 /// The exception, `try_header()`, is explicit by returning a
 /// `Result<Builder2>`.
 ///
-/// See also [`Builder`](struct.Builder.html).
+/// See also [`Builder`]
 #[derive(Debug)]
 pub struct Builder2 {
     inner: Parts,
@@ -254,14 +257,14 @@ impl Response<()> {
     /// ```
     #[inline]
     #[deprecated(note = "Please use Self::builder2, it will replace Builder")]
-    #[allow(deprecated)]
     pub fn builder() -> Builder {
+        #[allow(deprecated)]
         Builder::new()
     }
 
     /// Creates a new builder-style object to manufacture a `Response`
     ///
-    /// This method returns an instance of `Builder` which can be used to
+    /// This method returns an instance of `Builder2` which can be used to
     /// create a `Response`.
     /// This builder can not represent an erroneous state, so as long
     /// as you have a `Builder2` you can get a `Response`.
@@ -577,7 +580,6 @@ impl fmt::Debug for Parts {
     }
 }
 
-#[allow(deprecated)]
 impl Builder {
     /// Creates a new default instance of `Builder` to construct either a
     /// `Head` or a `Response`.
@@ -615,6 +617,7 @@ impl Builder {
     ///     .body(())
     ///     .unwrap();
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn status<T>(self, status: T) -> Builder
     where
         StatusCode: TryFrom<T>,
@@ -643,6 +646,7 @@ impl Builder {
     ///     .body(())
     ///     .unwrap();
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn version(self, version: Version) -> Builder {
         self.and_then(move |mut head| {
             head.version = version;
@@ -669,6 +673,7 @@ impl Builder {
     ///     .body(())
     ///     .unwrap();
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn header<K, V>(self, key: K, value: V) -> Builder
     where
         HeaderName: TryFrom<K>,
@@ -700,6 +705,7 @@ impl Builder {
     /// assert_eq!( headers["Accept"], "text/html" );
     /// assert_eq!( headers["X-Custom-Foo"], "bar" );
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn headers_ref(&self) -> Option<&HeaderMap<HeaderValue>> {
         self.inner.as_ref().ok().map(|h| &h.headers)
     }
@@ -723,6 +729,7 @@ impl Builder {
     /// assert_eq!( headers["Accept"], "text/html" );
     /// assert_eq!( headers["X-Custom-Foo"], "bar" );
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn headers_mut(&mut self) -> Option<&mut HeaderMap<HeaderValue>> {
         self.inner.as_mut().ok().map(|h| &mut h.headers)
     }
@@ -742,6 +749,7 @@ impl Builder {
     /// assert_eq!(response.extensions().get::<&'static str>(),
     ///            Some(&"My Extension"));
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn extension<T>(self, extension: T) -> Builder
     where
         T: Any + Send + Sync + 'static,
@@ -765,6 +773,7 @@ impl Builder {
     /// assert_eq!(extensions.get::<&'static str>(), Some(&"My Extension"));
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn extensions_ref(&self) -> Option<&Extensions> {
         self.inner.as_ref().ok().map(|h| &h.extensions)
     }
@@ -783,6 +792,7 @@ impl Builder {
     /// extensions.insert(5u32);
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
         self.inner.as_mut().ok().map(|h| &mut h.extensions)
     }
@@ -807,6 +817,7 @@ impl Builder {
     ///     .body(())
     ///     .unwrap();
     /// ```
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn body<T>(self, body: T) -> Result<Response<T>> {
         self.inner.map(move |head| {
             Response {
@@ -828,7 +839,6 @@ impl Builder {
     }
 }
 
-#[allow(deprecated)]
 impl Default for Builder {
     #[inline]
     fn default() -> Builder {
@@ -858,7 +868,7 @@ impl Builder2 {
     /// Set the HTTP status for this response.
     ///
     /// This function will configure the HTTP status code of the `Response` that
-    /// will be returned from `Builder::build`.
+    /// will be returned from `Builder2::build`.
     ///
     /// By default this is `200`.
     ///
@@ -987,7 +997,6 @@ impl Builder2 {
     /// ```
     /// # use http::*;
     /// # use http::header::HeaderValue;
-    /// //# use http::response::Builder;
     /// let mut res = Response::builder2();
     /// {
     ///   let headers = res.headers_mut();
@@ -1100,11 +1109,11 @@ impl Default for Builder2 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Response;
 
     #[test]
-    #[allow(deprecated)]
     fn it_can_map_a_body_from_one_type_to_another() {
+        #[allow(deprecated)]
         let response = Response::builder().body("some string").unwrap();
         let mapped_response = response.map(|s| {
             assert_eq!(s, "some string");

--- a/src/response.rs
+++ b/src/response.rs
@@ -886,6 +886,35 @@ impl Builder2 {
         self
     }
 
+    /// Try to Set the HTTP status for this response.
+    ///
+    /// This function will configure the HTTP status code of the `Response` that
+    /// will be returned from `Builder2::build`, using a fallible conversion.
+    /// If the conversion succeeds, the `Builder2` is updated with the status.
+    /// If the conversion fails, the `Builder2` is discarded and the error is returned.
+    ///
+    /// By default the status is `200`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    /// # fn main() -> Result<()> {
+    /// let response = Response::builder2()
+    ///     .try_status(404)?
+    ///     .body(());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_status<T>(self, status: T) -> Result<Builder2>
+    where
+        StatusCode: TryFrom<T>,
+        crate::Error: From<<StatusCode as TryFrom<T>>::Error>,
+    {
+        use std::convert::TryInto;
+        Ok(self.status(status.try_into()?))
+    }
+
     /// Set the HTTP version for this response.
     ///
     /// This function will configure the HTTP version of the `Response` that

--- a/src/response.rs
+++ b/src/response.rs
@@ -210,6 +210,7 @@ pub struct Parts {
 ///
 /// See also [`Builder2`](struct.Builder2.html).
 #[derive(Debug)]
+#[deprecated(note = "Please use Self::builder2, it will replace Builder")]
 pub struct Builder {
     inner: Result<Parts>,
 }
@@ -252,6 +253,8 @@ impl Response<()> {
     ///     .unwrap();
     /// ```
     #[inline]
+    #[deprecated(note = "Please use Self::builder2, it will replace Builder")]
+    #[allow(deprecated)]
     pub fn builder() -> Builder {
         Builder::new()
     }
@@ -574,6 +577,7 @@ impl fmt::Debug for Parts {
     }
 }
 
+#[allow(deprecated)]
 impl Builder {
     /// Creates a new default instance of `Builder` to construct either a
     /// `Head` or a `Response`.
@@ -589,6 +593,7 @@ impl Builder {
     ///     .unwrap();
     /// ```
     #[inline]
+    #[deprecated(note = "Please use Builder2, it will replace Builder")]
     pub fn new() -> Builder {
         Builder::default()
     }
@@ -823,6 +828,7 @@ impl Builder {
     }
 }
 
+#[allow(deprecated)]
 impl Default for Builder {
     #[inline]
     fn default() -> Builder {
@@ -1097,8 +1103,19 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn it_can_map_a_body_from_one_type_to_another() {
         let response = Response::builder().body("some string").unwrap();
+        let mapped_response = response.map(|s| {
+            assert_eq!(s, "some string");
+            123u32
+        });
+        assert_eq!(mapped_response.body(), &123u32);
+    }
+
+    #[test]
+    fn it_can_map_a_body_from_one_type_to_another_2() {
+        let response = Response::builder2().body("some string");
         let mapped_response = response.map(|s| {
             assert_eq!(s, "some string");
             123u32


### PR DESCRIPTION
Fixes one part of #330.  Creating a Response with the builder pattern should not require handling errors unless opting in by using a `try_`-method (which returns a `Result<Builder2>`, not a `Builder2` with an internal error state).

This is really a breaking change to `response::Builder`, but rather than suggesting a breaking change directly, I introduce an alternative `response::Builder2`.  If this is accepted, the original `Builder` is deprecated, and in a later release `Builder2` can be renamed back to `Builder`.