### PR TITLE
add Uri#to_builder() to easily modify a part of Uri

### DIFF
--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -448,6 +448,12 @@ impl FromStr for Authority {
     }
 }
 
+impl From<&Authority> for Authority {
+    fn from(s: &Authority) -> Authority {
+        s.clone()
+    }
+}
+
 impl fmt::Debug for Authority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -673,6 +673,21 @@ impl Uri {
     fn has_path(&self) -> bool {
         !self.path_and_query.data.is_empty() || !self.scheme.inner.is_none()
     }
+
+    /// make a Uri::Builder from the Uri to modify part of it
+    pub fn to_builder(&self) -> Builder {
+        let mut builder = Self::builder();
+        if let Some(scheme) = self.scheme() {
+            builder = builder.scheme(scheme);
+        }
+        if let Some(authority) = self.authority() {
+            builder = builder.authority(authority);
+        }
+        if let Some(path_and_query) = self.path_and_query() {
+            builder = builder.path_and_query(path_and_query);
+        }
+        builder
+    }
 }
 
 impl<'a> TryFrom<&'a [u8]> for Uri {

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -287,6 +287,12 @@ impl FromStr for PathAndQuery {
     }
 }
 
+impl From<&PathAndQuery> for PathAndQuery {
+    fn from(s: &PathAndQuery) -> PathAndQuery {
+        s.clone()
+    }
+}
+
 impl fmt::Debug for PathAndQuery {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -105,6 +105,12 @@ impl FromStr for Scheme {
     }
 }
 
+impl From<&Scheme> for Scheme {
+    fn from(s: &Scheme) -> Scheme {
+        s.clone()
+    }
+}
+
 impl fmt::Debug for Scheme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -11,6 +11,16 @@ fn test_char_table() {
     }
 }
 
+#[test]
+fn test_to_builder() {
+    let uri = Uri::from_static("http://example.com/foo?bar=baz");
+    let modified_uri = uri.to_builder()
+        .path_and_query("/")
+        .build()
+        .unwrap();
+    assert_eq!(modified_uri, "http://example.com/");
+}
+
 macro_rules! part {
     ($s:expr) => {
         Some(&$s.parse().unwrap())


### PR DESCRIPTION
It is messy to modify a `Uri` instance with `Uri::Builder`. For example, if one wants to modify `path_and_query`, they should do something like this:

```rust
let uri: &Uri = req.uri();
let path_and_query: String = "...";
let parts = uri.clone().into_parts();
let modified_uri = Uri::builder()
    .scheme(parts.scheme.unwrap())
    .authority(parts.authority.unwrap())
    .path_and_query(path_and_query.as_str())
    .build()
    .unwrap();
```

With this PR, it will become:

```rust
let uri: &Uri = req.uri();
let path_and_query: String = "...";
let modified_uri = uri.to_builder()
    .path_and_query(path_and_query.as_str())
    .build()
    .unwrap();
```

It will let us focus on the concern.

What do you think of it?