### PR TITLE
StatusCode TryFrom and PartialEq with integer types

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -526,8 +526,7 @@ impl fmt::Debug for Parts {
 }
 
 impl Builder {
-    /// Creates a new default instance of `Builder` to construct either a
-    /// `Head` or a `Response`.
+    /// Creates a new default instance of `Builder` to construct a `Response`.
     ///
     /// # Examples
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -221,7 +221,7 @@ impl Response<()> {
     /// ```
     /// # use http::*;
     /// let response = Response::builder()
-    ///     .status(200)
+    ///     .status(StatusCode::OK)
     ///     .header("X-Custom-Foo", "Bar")
     ///     .body(())
     ///     .unwrap();
@@ -534,8 +534,8 @@ impl Builder {
     /// # use http::*;
     ///
     /// let response = response::Builder::new()
-    ///     .status(200)
-    ///     .body(())
+    ///     .status(StatusCode::OK)
+    ///     .body("hello world")
     ///     .unwrap();
     /// ```
     #[inline]
@@ -548,7 +548,7 @@ impl Builder {
     /// This function will configure the HTTP status code of the `Response` that
     /// will be returned from `Builder::build`.
     ///
-    /// By default this is `200`.
+    /// By default this is [`StatusCode::OK`].
     ///
     /// # Examples
     ///
@@ -556,7 +556,7 @@ impl Builder {
     /// # use http::*;
     ///
     /// let response = Response::builder()
-    ///     .status(200)
+    ///     .status(StatusCode::NO_CONTENT)
     ///     .body(())
     ///     .unwrap();
     /// ```

--- a/tests/status_code.rs
+++ b/tests/status_code.rs
@@ -26,9 +26,20 @@ fn from_bytes() {
 fn conversions() {
     let min = StatusCode::CONTINUE;
     assert_eq!(min.try_into(), Ok(100u16));
+    assert_eq!(min.try_into(), Ok(100u32));
+    assert_eq!(min.try_into(), Ok(100usize));
+    assert_eq!(min.try_into(), Ok(100u64));
+    assert_eq!(min.try_into(), Ok(100i32));
 
     let max = StatusCode::try_from(999).unwrap();
     assert_eq!(u16::from(max), 999);
+    assert_eq!(u32::from(max), 999);
+    assert_eq!(u64::from(max), 999);
+    assert_eq!(usize::from(max), 999);
+    assert_eq!(i16::from(max), 999);
+    assert_eq!(i32::from(max), 999);
+    assert_eq!(i64::from(max), 999);
+    assert_eq!(isize::from(max), 999);
 }
 
 #[test]
@@ -36,8 +47,21 @@ fn partial_eq_ne() {
     let status = StatusCode::from_u16(200u16).unwrap();
     assert_eq!(200u16, status);
     assert_eq!(status, 200u16);
+
+    assert_eq!(200i16, status);
+    assert_eq!(status, 200i16);
+
+    assert_eq!(200u32, status);
+    assert_eq!(status, 200u32);
+
+    assert_eq!(200u64, status);
+    assert_eq!(status, 200u64);
+
     assert_ne!(status, 201u16);
+    assert_ne!(status, 201u32);
     assert_ne!(status, 0u16);
+    assert_ne!(status, -3000i16);
+    assert_ne!(status, -10000i32);
 }
 
 #[test]

--- a/tests/status_code.rs
+++ b/tests/status_code.rs
@@ -1,25 +1,43 @@
 use http::*;
+use std::convert::{TryFrom, TryInto};
 
 #[test]
 fn from_bytes() {
     for ok in &[
-        "100", "101", "199", "200", "250", "299", "321", "399", "499", "599", "600", "999"
+        "100", "101", "199", "200", "250", "299",
+        "321", "399", "499", "599", "600", "999"
     ] {
         assert!(StatusCode::from_bytes(ok.as_bytes()).is_ok());
     }
 
     for not_ok in &[
-        "0", "00", "10", "40", "99", "000", "010", "099", "1000", "1999",
+        "-100", "-10", "", "0", "00", "000",
+        "10", "40", "99", "010","099",
+        "1000", "1999"
     ] {
         assert!(StatusCode::from_bytes(not_ok.as_bytes()).is_err());
     }
+
+    let giant = Box::new([b'9'; 1*1024*1024]);
+    assert!(StatusCode::from_bytes(&giant[..]).is_err());
 }
 
 #[test]
-fn equates_with_u16() {
+fn conversions() {
+    let min = StatusCode::CONTINUE;
+    assert_eq!(min.try_into(), Ok(100u16));
+
+    let max = StatusCode::try_from(999).unwrap();
+    assert_eq!(u16::from(max), 999);
+}
+
+#[test]
+fn partial_eq_ne() {
     let status = StatusCode::from_u16(200u16).unwrap();
     assert_eq!(200u16, status);
     assert_eq!(status, 200u16);
+    assert_ne!(status, 201u16);
+    assert_ne!(status, 0u16);
 }
 
 #[test]


### PR DESCRIPTION
As suggested in #230, I added `TryFrom` `<usize>`, `<u32>` and `<u64>` and `From<StatusCode>` for the same integer types, and re-implemented `<u16>` with the same macro.

Oddly enough, if I stop there, then previously working doctests for response::{Response, Builder} start failing with the following:

```text
error[E0277]: the trait bound `StatusCode: From<i32>` is not satisfied
 --> src/response.rs:537:6
  |
7 |     .status(200)
  |      ^^^^^^ the trait `From<i32>` is not implemented for `StatusCode`
  |
  = help: the following implementations were found:
            <StatusCode as From<&'a StatusCode>>
  = note: required because of the requirements on the impl of `Into<StatusCode>` for `i32`
  = note: required because of the requirements on the impl of `TryFrom<i32>` for `StatusCode`
```

...which seems almost more like an obscure rustc or stdlib bug? (Fails on MSRV 1.39.0 as well as a recent nightly). As this was done with `macro_rules!`, it was very easy to just extend it to the types signed `i16`, `i32`, `isize`, and `i64` types which avoids the above issue.  Since its implemented via `u16::try_from` there is nothing particularly more unusual about including support for the signed types: negative values are just another case of `InvalidStatusCode`. 

Also added bi-directional `PartialEq` for all of these integer types.  This makes it so `u16` doesn't have any particular favor in the public interface other then the existing `StatusCode::from_u16` and `as_u16`.   If a user sticks to `TryInto`, `From` and `PartialEq` then `u16` (and `NonZeroU16`) is just a private implementation detail. 

The PR includes some misc related test and doc improvements. 

Given the warning of the about mentioned compile error, I would not suggest merging this for release in a patch release like 0.2.2.  It warrants at least a MINOR bump 0.3.0 or 1.0.0.

Fixes #230 