### PR TITLE
StatusCode::as_str should return a &'static str (try 3)

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -132,7 +132,7 @@ impl StatusCode {
     /// assert_eq!(status.as_str(), "200");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         let offset = (self.0.get() - 100) as usize;
         let offset = offset * 3;
 


### PR DESCRIPTION
After various other changes, make `StatusCode::as_str` return a `&'static str`. 

Since 'static is a longer lifetime, I don't think this constitutes a breaking change, but like #443, this _could_ be merged for release of a new MINOR (0.3.0) or MAJOR (1.0.0), just to be cautious. 

(Supersedes) closes: #380 #436 (I rebased #380 here). 