### PR TITLE
Add StatusCode::EARLY_HINTS and TOO_EARLY constants

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -526,8 +526,7 @@ impl fmt::Debug for Parts {
 }
 
 impl Builder {
-    /// Creates a new default instance of `Builder` to construct either a
-    /// `Head` or a `Response`.
+    /// Creates a new default instance of `Builder` to construct a `Response`.
     ///
     /// # Examples
     ///

--- a/src/status.rs
+++ b/src/status.rs
@@ -330,6 +330,9 @@ status_codes! {
     /// 102 Processing
     /// [[RFC2518](https://tools.ietf.org/html/rfc2518)]
     (102, PROCESSING, "Processing");
+    /// 103 Early Hints
+    /// [[RFC8297](https://tools.ietf.org/html/rfc8297)]
+    (103, EARLY_HINTS, "Early Hints");
 
     /// 200 OK
     /// [[RFC7231, Section 6.3.1](https://tools.ietf.org/html/rfc7231#section-6.3.1)]
@@ -458,7 +461,9 @@ status_codes! {
     /// 424 Failed Dependency
     /// [[RFC4918](https://tools.ietf.org/html/rfc4918)]
     (424, FAILED_DEPENDENCY, "Failed Dependency");
-
+    /// 425 Too Early
+    /// [[RFC8470](https://tools.ietf.org/html/rfc8470)]
+    (425, TOO_EARLY, "Too Early");
     /// 426 Upgrade Required
     /// [[RFC7231, Section 6.5.15](https://tools.ietf.org/html/rfc7231#section-6.5.15)]
     (426, UPGRADE_REQUIRED, "Upgrade Required");

--- a/tests/status_code.rs
+++ b/tests/status_code.rs
@@ -1,25 +1,43 @@
 use http::*;
+use std::convert::{TryFrom, TryInto};
 
 #[test]
 fn from_bytes() {
     for ok in &[
-        "100", "101", "199", "200", "250", "299", "321", "399", "499", "599", "600", "999"
+        "100", "101", "199", "200", "250", "299",
+        "321", "399", "499", "599", "600", "999"
     ] {
         assert!(StatusCode::from_bytes(ok.as_bytes()).is_ok());
     }
 
     for not_ok in &[
-        "0", "00", "10", "40", "99", "000", "010", "099", "1000", "1999",
+        "-100", "-10", "", "0", "00", "000",
+        "10", "40", "99", "010","099",
+        "1000", "1999"
     ] {
         assert!(StatusCode::from_bytes(not_ok.as_bytes()).is_err());
     }
+
+    let giant = Box::new([b'9'; 1*1024*1024]);
+    assert!(StatusCode::from_bytes(&giant[..]).is_err());
 }
 
 #[test]
-fn equates_with_u16() {
+fn conversions() {
+    let min = StatusCode::CONTINUE;
+    assert_eq!(min.try_into(), Ok(100u16));
+
+    let max = StatusCode::try_from(999).unwrap();
+    assert_eq!(u16::from(max), 999);
+}
+
+#[test]
+fn partial_eq_ne() {
     let status = StatusCode::from_u16(200u16).unwrap();
     assert_eq!(200u16, status);
     assert_eq!(status, 200u16);
+    assert_ne!(status, 201u16);
+    assert_ne!(status, 0u16);
 }
 
 #[test]


### PR DESCRIPTION
The `StatusCode` docs imply full coverage of IANA status codes and these two were added after the original implementation. 

Its a highly safe change, but I'd wait for 1.0.0, treating it more like a new feature.

Closes #439 