### PR TITLE
Custom total `Ord` for `Uri` and its parts

### DIFF
--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -332,11 +332,18 @@ impl PartialEq<Authority> for String {
 /// assert!(authority < "ghi.com");
 /// assert!(authority > "abc.com");
 /// ```
-impl PartialOrd for Authority {
-    fn partial_cmp(&self, other: &Authority) -> Option<cmp::Ordering> {
+impl Ord for Authority {
+    fn cmp(&self, other: &Authority) -> cmp::Ordering {
         let left = self.data.as_bytes().iter().map(|b| b.to_ascii_lowercase());
         let right = other.data.as_bytes().iter().map(|b| b.to_ascii_lowercase());
-        left.partial_cmp(right)
+        left.cmp(right)
+    }
+}
+
+impl PartialOrd for Authority {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -27,6 +27,7 @@ use std::convert::TryFrom;
 
 use bytes::Bytes;
 
+use std::cmp;
 use std::error::Error;
 use std::hash::{Hash, Hasher};
 use std::str::{self, FromStr};
@@ -980,6 +981,32 @@ impl<'a> PartialEq<Uri> for &'a str {
 }
 
 impl Eq for Uri {}
+
+/// Order by `(Authority, Scheme, PathAndQuery)`, delegating to the custom
+/// case-insensitive `Ord` for [`Authority`] and [`Scheme`], and `str`
+/// byte-wise `Ord` for [`PathAndQuery`].
+impl PartialOrd for Uri {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Order by `(Authority, Scheme, PathAndQuery)`, delegating to the custom
+/// case-insensitive `Ord` for [`Authority`] and [`Scheme`], and `str`
+/// byte-wise `Ord` for [`PathAndQuery`].
+impl Ord for Uri {
+    fn cmp(&self, r: &Self) -> cmp::Ordering {
+        let mut ord = self.authority().cmp(&r.authority());
+        if ord == cmp::Ordering::Equal {
+            ord = self.scheme().cmp(&r.scheme());
+        }
+        if ord == cmp::Ordering::Equal {
+            ord = self.path_and_query().cmp(&r.path_and_query());
+        }
+        ord
+    }
+}
 
 /// Returns a `Uri` representing `/`
 impl Default for Uri {

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -375,10 +375,17 @@ impl PartialEq<PathAndQuery> for String {
     }
 }
 
+impl Ord for PathAndQuery {
+    #[inline]
+    fn cmp(&self, other: &PathAndQuery) -> cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
 impl PartialOrd for PathAndQuery {
     #[inline]
-    fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
-        self.as_str().partial_cmp(other.as_str())
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::convert::TryFrom;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -21,7 +22,7 @@ pub(super) enum Scheme2<T = Box<ByteStr>> {
     Other(T),
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) enum Protocol {
     Http,
     Https,
@@ -121,6 +122,30 @@ impl AsRef<str> for Scheme {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
+    }
+}
+
+/// Case-insensitive ordering
+impl Ord for Scheme {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        use self::Scheme2::*;
+        match (&self.inner, &other.inner) {
+            (&Standard(pl), &Standard(pr)) => {
+                pl.cmp(&pr)
+            }
+            _ => {
+                let l = self.as_str().chars().map(|b| b.to_ascii_lowercase());
+                let r = other.as_str().chars().map(|b| b.to_ascii_lowercase());
+                l.cmp(r)
+            }
+        }
+    }
+}
+
+impl PartialOrd for Scheme {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -517,3 +517,51 @@ fn test_partial_eq_path_with_terminating_questionmark() {
 
     assert_eq!(uri, a);
 }
+
+
+#[test]
+fn test_uri_ord() {
+    let unordered = vec![
+        "https://example.com/path?query",
+        "HTTP://EXAMPLE.COM/",
+        "http://example.COM/qath?query",
+        "http://example.com/",
+        "http://example.com/path?query",
+        "file://foo/bar/framis/",
+        "file://foo/bar/framiz",
+        "FILE://foo/bar/framis/",
+        "https://ACME.COM:80/",
+        "https://acme.com:443/",
+        "https://acme.com/",
+        "http://acme.com/",
+        "/path",
+        "/?query",
+        "/",
+    ];
+
+    let unordered: Vec<Uri> = unordered.iter()
+        .map(|s| Uri::from_str(s).expect(s))
+        .collect();
+
+    let mut ord = unordered.clone();
+    ord.sort(); // stable
+    let mut ord = ord.iter()
+        .map(ToString::to_string);
+
+    assert_eq!(ord.next().unwrap(), "/");
+    assert_eq!(ord.next().unwrap(), "/?query");
+    assert_eq!(ord.next().unwrap(), "/path");
+    assert_eq!(ord.next().unwrap(), "http://acme.com/");
+    assert_eq!(ord.next().unwrap(), "https://acme.com/");
+    assert_eq!(ord.next().unwrap(), "https://acme.com:443/");
+    assert_eq!(ord.next().unwrap(), "https://ACME.COM:80/");
+    assert_eq!(ord.next().unwrap(), "http://EXAMPLE.COM/");
+    assert_eq!(ord.next().unwrap(), "http://example.com/");
+    assert_eq!(ord.next().unwrap(), "http://example.com/path?query");
+    assert_eq!(ord.next().unwrap(), "http://example.COM/qath?query");
+    assert_eq!(ord.next().unwrap(), "https://example.com/path?query");
+    assert_eq!(ord.next().unwrap(), "file://foo/bar/framis/");
+    assert_eq!(ord.next().unwrap(), "FILE://foo/bar/framis/");
+    assert_eq!(ord.next().unwrap(), "file://foo/bar/framiz");
+    assert_eq!(ord.next(), None);
+}


### PR DESCRIPTION
The user requesting `Ord` for `Uri`  in #407 suggests that _some_ or even any impl of `PartialOrd` and `Ord` for `Uri` is helpful for composition. Its also necessary for inserting into `BTreeMap` and `BTreeSet`. The `Authority` and `Scheme` parts already have case-insensitive custom `Eq` impls (or in the case of `Authority`, `PartialOrd`). To have implemented `Eq` and `PartialOrd` without `Ord` could be viewed as a unintended omission.  Since the crate can offer but one total ordering for `Uri`, I argue here that the most natural ordering is by delegation to the parts in the order shown below, e.g. by (primary, secondary, tertiary) keys `(Authority, Scheme, PathAndQuery`).  To use `Scheme` as the secondary key (after `Authority`) is somewhat arbitrary, but subjectively, this better relates the relationships of DNS lookup, TLS, ports and paths.  The next obvious ordering would be `(Scheme, Authority, PathAndQuery)`.  It a breaking change to change it latter, so best to consider that fully now.

| Type |  Ordering | PR Commits |
|--------|----------|--------------|
| `Authority` | (existing `PartialOrd` + `Eq`) case-insensitive | b2d1ea6 |
| `Scheme`  | (existing `Eq`) case-insentive | 12eeefd |
| `PathAndQuery` | (existing `PartialOrd` + `Eq`) byte-wise | 09bcf39 |
| `Uri`                    | (existing `Eq`) compatible new: `(Authority, Scheme, PathAndQuery)` | 6d73729 |


(Implements) closes #407 