### PR TITLE
Broaden bytes dep to include version 0.5.z through 1.y 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.3 (unreleased)
+
+* Broaden bytes dependency to include versions 0.5.z through 1.y. The rare
+  broad dependency range is intended to allow users to avoid duplicates of the
+  bytes crate during transition to bytes 1.0.0 in the broader ecosystem, while
+  simultaneously avoiding a Semver incompatible release of _http_. ([#461])
+
 # 0.2.2 (December 14, 2020)
 
 * Fix (potential double) panic of (`HeaderMap`) `OccupiedEntry::remove_entry` and
@@ -159,11 +166,11 @@
 [#414]: https://github.com/hyperium/http/pull/414
 [#432]: https://github.com/hyperium/http/issues/432
 [#433]: https://github.com/hyperium/http/pull/433
+[#435]: https://github.com/hyperium/http/issues/435
 [#438]: https://github.com/hyperium/http/pull/438
 [#443]: https://github.com/hyperium/http/pull/443
+[#445]: https://github.com/hyperium/http/pull/445
 [#446]: https://github.com/hyperium/http/issues/446
 [#449]: https://github.com/hyperium/http/pull/449
 [#450]: https://github.com/hyperium/http/pull/450
-[#435]: https://github.com/hyperium/http/issues/435
-[#445]: https://github.com/hyperium/http/pull/445
-
+[#461]: https://github.com/hyperium/http/pull/461

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["web-programming"]
 edition = "2018"
 
 [dependencies]
-bytes = "1"
+bytes = ">=0.5.2, <2.0.0"
 fnv = "1.0.5"
 itoa = "0.4.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "http"
 # - Update html_root_url in lib.rs.
 # - Update CHANGELOG.md.
 # - Create git tag
-version = "0.2.2"
+version = "0.2.3"
 readme = "README.md"
 documentation = "https://docs.rs/http"
 repository = "https://github.com/hyperium/http"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/http/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/http/0.2.3")]
 
 //! A general purpose library of common HTTP types
 //!


### PR DESCRIPTION
This is one alternative discussed in #457 [comment](https://github.com/hyperium/http/pull/440#issuecomment-721894116) and on discord, to releasing an http 0.2.3 that _forces_ as per current master, existing _hyper_ 0.13 (_tokio_ 0.2, etc.) applications to have duplicate _bytes_ crates in their dependency graph.  I'm PRing this for CI and in case it helps.

Duplicates are at minimum a build time and cosmetic liability, and at maximum cause compiler errors or even subtle bugs. Note that the worst case is _usually_ due to the dependency being in the public API, but in the case of _http_, _bytes_ is currently private.

This broad dependency range is only particularly appropriate for a patch release 0.2.3 and could be reverted (in favor of a bytes = "^1.0.0" dependency) in a 1.0.0 release.


## Expected behavior from user perspective

Just to clarify how this expected to work, and as reference for users who might want to manually intervene to avoid the duplicate:

### With an existing Cargo.lock and dependency on _http_ 0.2.x

Dry run the update:

```text
% cargo update --dry-run
    Updating crates.io index
      Adding bytes v1.0.0
    Updating http v0.2.2 -> v0.2.3
```

To update http, _without_ adding bytes 1.0.0:

```text
% cargo update -p http
    Updating crates.io index
    Updating http v0.2.2 -> v0.2.3
```

### Without a lock file

On a new install without an existing `Cargo.lock`, for example new clone of application that doesn't track `Cargo.lock`, or via `cargo install`, a duplicate of bytes is expected:

```text
% cargo tree --duplicates

bytes v0.5.6
├── h2 v0.2.7
│   └── hyper v0.13.9
│       └── my_app v1.3.0
├── http-body v0.3.1 (*)
├── hyper v0.13.9 (*)
├── tokio v0.2.24
│   ├── h2 v0.2.7 (*)
│   ├── hyper v0.13.9 (*)
│   └── tokio-util v0.3.1
│       └── h2 v0.2.7 (*)
└── tokio-util v0.3.1 (*)

bytes v1.0.0
└── http v0.2.3
    └── my_app v1.3.0
```

...but with this PR, this can be manually avoided by the user:


```
% cargo update -p bytes:1.0.0 --precise 0.5.6
   Updating crates.io index
   Removing bytes v1.0.0
```

Without this PR, (if released as per current master, 95c338e) this would not be an option. The only option would be to not update to _http_ 0.2.3, but this effectively cuts the user/application off from potentially important future bug fixes, including security fixes!

