### PR TITLE
Make StatusCode::as_str return &'static str

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -132,7 +132,7 @@ impl StatusCode {
     /// assert_eq!(status.as_str(), "200");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         let offset = (self.0.get() - 100) as usize;
         let offset = offset * 3;
 


### PR DESCRIPTION
The lifetime of the returned `&str` was implicitly `pub fn as_str<'a>(&'a self) -> &'a str`. This changes that to `pub fn as_str<'a>(&'a self) -> &'static str`. This would allow me to use the returned `&str` in my project without having to clone it into an owned `String` first.