### PR TITLE
Add lifetime to HttpValues for non-copying response headers

### DIFF
--- a/benches/header_value.rs
+++ b/benches/header_value.rs
@@ -28,6 +28,23 @@ fn from_shared_long(b: &mut Bencher) {
 }
 
 #[bench]
+fn from_static_short(b: &mut Bencher) {
+    b.bytes = SHORT.len() as u64;
+    b.iter(|| {
+        HeaderValue::from_bytes_ref(SHORT).unwrap();
+    });
+}
+
+#[bench]
+fn from_static_long(b: &mut Bencher) {
+    b.bytes = LONG.len() as u64;
+    let bytes = Bytes::from_static(LONG);
+    b.iter(|| {
+        HeaderValue::from_bytes_ref(LONG).unwrap();
+    });
+}
+
+#[bench]
 fn from_shared_unchecked_short(b: &mut Bencher) {
     b.bytes = SHORT.len() as u64;
     let bytes = Bytes::from_static(SHORT);

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -42,7 +42,7 @@ pub use self::into_header_name::IntoHeaderName;
 /// assert!(!headers.contains_key(HOST));
 /// ```
 #[derive(Clone)]
-pub struct HeaderMap<T = HeaderValue> {
+pub struct HeaderMap<T = HeaderValue<'static>> {
     // Used to mask values to get an index
     mask: Size,
     indices: Box<[Pos]>,
@@ -1835,7 +1835,6 @@ impl<T> FromIterator<(HeaderName, T)> for HeaderMap<T> {
 ///
 /// let mut map = HashMap::new();
 /// map.insert("X-Custom-Header".to_string(), "my value".to_string());
-///
 /// let headers: HeaderMap = (&map).try_into().expect("valid headers");
 /// assert_eq!(headers["X-Custom-Header"], "my value");
 /// ```

--- a/src/request.rs
+++ b/src/request.rs
@@ -174,7 +174,7 @@ pub struct Parts {
     pub version: Version,
 
     /// The request's headers
-    pub headers: HeaderMap<HeaderValue>,
+    pub headers: HeaderMap<HeaderValue<'static>>,
 
     /// The request's extensions
     pub extensions: Extensions,
@@ -560,7 +560,7 @@ impl<T> Request<T> {
     /// assert!(request.headers().is_empty());
     /// ```
     #[inline]
-    pub fn headers(&self) -> &HeaderMap<HeaderValue> {
+    pub fn headers(&self) -> &HeaderMap<HeaderValue<'static>> {
         &self.head.headers
     }
 
@@ -576,7 +576,7 @@ impl<T> Request<T> {
     /// assert!(!request.headers().is_empty());
     /// ```
     #[inline]
-    pub fn headers_mut(&mut self) -> &mut HeaderMap<HeaderValue> {
+    pub fn headers_mut(&mut self) -> &mut HeaderMap<HeaderValue<'static>> {
         &mut self.head.headers
     }
 
@@ -900,8 +900,8 @@ impl Builder {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<crate::Error>,
-        HeaderValue: TryFrom<V>,
-        <HeaderValue as TryFrom<V>>::Error: Into<crate::Error>,
+        HeaderValue<'static>: TryFrom<V>,
+        <HeaderValue<'static> as TryFrom<V>>::Error: Into<crate::Error>,
     {
         self.and_then(move |mut head| {
             let name = <HeaderName as TryFrom<K>>::try_from(key).map_err(Into::into)?;
@@ -947,7 +947,7 @@ impl Builder {
     /// assert_eq!( headers["Accept"], "text/html" );
     /// assert_eq!( headers["X-Custom-Foo"], "bar" );
     /// ```
-    pub fn headers_mut(&mut self) -> Option<&mut HeaderMap<HeaderValue>> {
+    pub fn headers_mut(&mut self) -> Option<&mut HeaderMap<HeaderValue<'static>>> {
         self.inner.as_mut().ok().map(|h| &mut h.headers)
     }
 


### PR DESCRIPTION
This is a draft PR for adding lifetimes HeaderValues, HeaderMap, and Response, so that header _values_ can borrow from something with some longer lifetime.

The patch is implemented by suggestion from @SergioBenitez: This would reduce allocation in a number of cases and would match Rocket's current API for https://github.com/SergioBenitez/Rocket/issues/1498

There appears to be a slight time overhead due to the enum storing either a `&[u8]` reference instead of just the `Bytes` struct, but no noticeable impact otherwise. I've included a benchmark for the borrow case, and it appears to give the expected benefits.

As submitted, the patch breaks 9 doctests, and needs a bit of doc touches. I'll fix those if there is interest in adding this borrowing variation.