### PR TITLE
Bring back `TryFrom<Bytes>` implementations

### DIFF
--- a/benches/header_value.rs
+++ b/benches/header_value.rs
@@ -2,6 +2,8 @@
 
 extern crate test;
 
+use std::convert::TryFrom;
+
 use bytes::Bytes;
 use http::HeaderValue;
 use test::Bencher;
@@ -14,7 +16,7 @@ fn from_shared_short(b: &mut Bencher) {
     b.bytes = SHORT.len() as u64;
     let bytes = Bytes::from_static(SHORT);
     b.iter(|| {
-        HeaderValue::from_maybe_shared(bytes.clone()).unwrap();
+        HeaderValue::try_from(bytes.clone()).unwrap();
     });
 }
 
@@ -23,7 +25,7 @@ fn from_shared_long(b: &mut Bencher) {
     b.bytes = LONG.len() as u64;
     let bytes = Bytes::from_static(LONG);
     b.iter(|| {
-        HeaderValue::from_maybe_shared(bytes.clone()).unwrap();
+        HeaderValue::try_from(bytes.clone()).unwrap();
     });
 }
 

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -118,14 +118,14 @@ macro_rules! standard_headers {
                 // Test lower case
                 let name_bytes = name.as_bytes();
                 let bytes: Bytes =
-                    HeaderName::from_bytes(name_bytes).unwrap().inner.into();
+                    HeaderName::from_bytes(name_bytes).unwrap().into();
                 assert_eq!(bytes, name_bytes);
                 assert_eq!(HeaderName::from_bytes(name_bytes).unwrap(), std);
 
                 // Test upper case
                 let upper = name.to_uppercase().to_string();
                 let bytes: Bytes =
-                    HeaderName::from_bytes(upper.as_bytes()).unwrap().inner.into();
+                    HeaderName::from_bytes(upper.as_bytes()).unwrap().into();
                 assert_eq!(bytes, name.as_bytes());
                 assert_eq!(HeaderName::from_bytes(upper.as_bytes()).unwrap(),
                            std);
@@ -1800,10 +1800,6 @@ impl HeaderName {
             Repr::Custom(ref v) => &*v.0,
         }
     }
-
-    pub(super) fn into_bytes(self) -> Bytes {
-        self.inner.into()
-    }
 }
 
 impl FromStr for HeaderName {
@@ -1876,6 +1872,13 @@ impl From<Custom> for Bytes {
     }
 }
 
+impl From<HeaderName> for Bytes {
+    #[inline]
+    fn from(name: HeaderName) -> Bytes {
+        name.inner.into()
+    }
+}
+
 impl<'a> TryFrom<&'a str> for HeaderName {
     type Error = InvalidHeaderName;
     #[inline]
@@ -1897,6 +1900,14 @@ impl<'a> TryFrom<&'a [u8]> for HeaderName {
     #[inline]
     fn try_from(s: &'a [u8]) -> Result<Self, Self::Error> {
         Self::from_bytes(s)
+    }
+}
+
+impl TryFrom<Bytes> for HeaderName {
+    type Error = InvalidHeaderName;
+    #[inline]
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes.as_ref())
     }
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -372,7 +372,7 @@ impl From<HeaderName> for HeaderValue {
     #[inline]
     fn from(h: HeaderName) -> HeaderValue {
         HeaderValue {
-            inner: h.into_bytes(),
+            inner: h.into(),
             is_sensitive: false,
         }
     }
@@ -490,6 +490,13 @@ impl FromStr for HeaderValue {
     }
 }
 
+impl From<HeaderValue> for Bytes {
+    #[inline]
+    fn from(value: HeaderValue) -> Bytes {
+        value.inner
+    }
+}
+
 impl<'a> From<&'a HeaderValue> for HeaderValue {
     #[inline]
     fn from(t: &'a HeaderValue) -> Self {
@@ -538,6 +545,15 @@ impl TryFrom<Vec<u8>> for HeaderValue {
     #[inline]
     fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
         HeaderValue::from_shared(vec.into())
+    }
+}
+
+impl TryFrom<Bytes> for HeaderValue {
+    type Error = InvalidHeaderValue;
+
+    #[inline]
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        HeaderValue::from_shared(bytes)
     }
 }
 

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -250,61 +250,10 @@ impl Uri {
         T: AsRef<[u8]> + 'static,
     {
         if_downcast_into!(T, Bytes, src, {
-            return Uri::from_shared(src);
+            return Uri::try_from(src);
         });
 
         Uri::try_from(src.as_ref())
-    }
-
-    // Not public while `bytes` is unstable.
-    fn from_shared(s: Bytes) -> Result<Uri, InvalidUri> {
-        use self::ErrorKind::*;
-
-        if s.len() > MAX_LEN {
-            return Err(TooLong.into());
-        }
-
-        match s.len() {
-            0 => {
-                return Err(Empty.into());
-            }
-            1 => match s[0] {
-                b'/' => {
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: Authority::empty(),
-                        path_and_query: PathAndQuery::slash(),
-                    });
-                }
-                b'*' => {
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: Authority::empty(),
-                        path_and_query: PathAndQuery::star(),
-                    });
-                }
-                _ => {
-                    let authority = Authority::from_shared(s)?;
-
-                    return Ok(Uri {
-                        scheme: Scheme::empty(),
-                        authority: authority,
-                        path_and_query: PathAndQuery::empty(),
-                    });
-                }
-            },
-            _ => {}
-        }
-
-        if s[0] == b'/' {
-            return Ok(Uri {
-                scheme: Scheme::empty(),
-                authority: Authority::empty(),
-                path_and_query: PathAndQuery::from_shared(s)?,
-            });
-        }
-
-        parse_full(s)
     }
 
     /// Convert a `Uri` from a static string.
@@ -327,7 +276,7 @@ impl Uri {
     /// ```
     pub fn from_static(src: &'static str) -> Self {
         let s = Bytes::from_static(src.as_bytes());
-        match Uri::from_shared(s) {
+        match Uri::try_from(s) {
             Ok(uri) => uri,
             Err(e) => panic!("static str is not valid URI: {}", e),
         }
@@ -675,12 +624,86 @@ impl Uri {
     }
 }
 
+impl TryFrom<Bytes> for Uri {
+    type Error = InvalidUri;
+
+    /// Attempt to convert a `Uri` from `Bytes`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate http;
+    /// # use http::uri::*;
+    /// extern crate bytes;
+    ///
+    /// use std::convert::TryFrom;
+    /// use bytes::Bytes;
+    ///
+    /// # pub fn main() {
+    /// let bytes = Bytes::from("http://example.com/foo");
+    /// let uri = Uri::try_from(bytes).unwrap();
+    ///
+    /// assert_eq!(uri.host().unwrap(), "example.com");
+    /// assert_eq!(uri.path(), "/foo");
+    /// # }
+    /// ```
+    fn try_from(s: Bytes) -> Result<Uri, Self::Error> {
+        use self::ErrorKind::*;
+
+        if s.len() > MAX_LEN {
+            return Err(TooLong.into());
+        }
+
+        match s.len() {
+            0 => {
+                return Err(Empty.into());
+            }
+            1 => match s[0] {
+                b'/' => {
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: Authority::empty(),
+                        path_and_query: PathAndQuery::slash(),
+                    });
+                }
+                b'*' => {
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: Authority::empty(),
+                        path_and_query: PathAndQuery::star(),
+                    });
+                }
+                _ => {
+                    let authority = Authority::try_from(s)?;
+
+                    return Ok(Uri {
+                        scheme: Scheme::empty(),
+                        authority: authority,
+                        path_and_query: PathAndQuery::empty(),
+                    });
+                }
+            },
+            _ => {}
+        }
+
+        if s[0] == b'/' {
+            return Ok(Uri {
+                scheme: Scheme::empty(),
+                authority: Authority::empty(),
+                path_and_query: PathAndQuery::try_from(s)?,
+            });
+        }
+
+        parse_full(s)
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for Uri {
     type Error = InvalidUri;
 
     #[inline]
     fn try_from(t: &'a [u8]) -> Result<Self, Self::Error> {
-        Uri::from_shared(Bytes::copy_from_slice(t))
+        Uri::try_from(Bytes::copy_from_slice(t))
     }
 }
 
@@ -707,7 +730,7 @@ impl TryFrom<String> for Uri {
 
     #[inline]
     fn try_from(t: String) -> Result<Self, Self::Error> {
-        Uri::from_shared(Bytes::from(t))
+        Uri::try_from(Bytes::from(t))
     }
 }
 
@@ -847,7 +870,7 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
     Ok(Uri {
         scheme: scheme.into(),
         authority: authority,
-        path_and_query: PathAndQuery::from_shared(s)?,
+        path_and_query: PathAndQuery::try_from(s)?,
     })
 }
 


### PR DESCRIPTION
This is mostly a revert of commit 4ce5e6a3a33c6548f885972db6f23450be18e133, but this does not bring back the error variants suffixed with `Bytes` (db9b1b9a76ce9c0b366fc6fff433ca4ca00571d1).

This also replaces usages of the internal `from_shared` associated functions with `try_from`.

Closes #459.