### PR TITLE
Add TryFrom implementations for owned types for HeaderName

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1728,11 +1728,11 @@ impl HeaderName {
     /// Converts a static string to a HTTP header name.
     ///
     /// This function panics when the static string is a invalid header.
-    /// 
-    /// This function requires the static string to only contain lowercase 
-    /// characters, numerals and symbols, as per the HTTP/2.0 specification 
+    ///
+    /// This function requires the static string to only contain lowercase
+    /// characters, numerals and symbols, as per the HTTP/2.0 specification
     /// and header names internal representation within this library.
-    /// 
+    ///
     ///
     /// # Examples
     ///
@@ -1741,21 +1741,21 @@ impl HeaderName {
     /// // Parsing a standard header
     /// let hdr = HeaderName::from_static("content-length");
     /// assert_eq!(CONTENT_LENGTH, hdr);
-    /// 
+    ///
     /// // Parsing a custom header
     /// let CUSTOM_HEADER: &'static str = "custom-header";
-    /// 
+    ///
     /// let a = HeaderName::from_lowercase(b"custom-header").unwrap();
     /// let b = HeaderName::from_static(CUSTOM_HEADER);
     /// assert_eq!(a, b);
     /// ```
-    /// 
+    ///
     /// ```should_panic
     /// # use http::header::*;
     /// #
     /// // Parsing a header that contains invalid symbols(s):
     /// HeaderName::from_static("content{}{}length"); // This line panics!
-    /// 
+    ///
     /// // Parsing a header that contains invalid uppercase characters.
     /// let a = HeaderName::from_static("foobar");
     /// let b = HeaderName::from_static("FOOBAR"); // This line panics!
@@ -1897,6 +1897,24 @@ impl<'a> TryFrom<&'a [u8]> for HeaderName {
     #[inline]
     fn try_from(s: &'a [u8]) -> Result<Self, Self::Error> {
         Self::from_bytes(s)
+    }
+}
+
+impl TryFrom<String> for HeaderName {
+    type Error = InvalidHeaderName;
+
+    #[inline]
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_bytes(s.as_bytes())
+    }
+}
+
+impl TryFrom<Vec<u8>> for HeaderName {
+    type Error = InvalidHeaderName;
+
+    #[inline]
+    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::from_bytes(&vec)
     }
 }
 
@@ -2238,7 +2256,7 @@ mod tests {
     #[test]
     fn test_from_static_std() {
         let a = HeaderName { inner: Repr::Standard(Vary) };
-        
+
         let b = HeaderName::from_static("vary");
         assert_eq!(a, b);
 
@@ -2250,13 +2268,13 @@ mod tests {
     #[should_panic]
     fn test_from_static_std_uppercase() {
         HeaderName::from_static("Vary");
-    } 
+    }
 
     #[test]
     #[should_panic]
     fn test_from_static_std_symbol() {
         HeaderName::from_static("vary{}");
-    } 
+    }
 
     // MaybeLower { lower: true }
     #[test]


### PR DESCRIPTION
`HeaderValue` implements `TryFrom` over both reference and owned types, but `HeaderName` does not. This seemed like an accidental omission to me rather than something intentionally absent. Including this conversion slightly increases ergonomics by allowing you to create a `HeaderMap` from a `HashMap<String, String>` and in similar other constraints.

See also https://github.com/sagebind/isahc/issues/314.