### PR TITLE
HeaderValue::from_static can be const

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.39.0
+          - 1.46.0
 
         include:
           - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-const_fn_assert = "0.1.2"
 fnv = "1.0.5"
 itoa = "0.4.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
+const_fn_assert = "0.1.2"
 fnv = "1.0.5"
 itoa = "0.4.1"
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -57,11 +57,15 @@ impl HeaderValue {
     /// assert_eq!(val, "hello");
     /// ```
     #[inline]
+    #[allow(unconditional_panic)] // required for the panic circumventon
+    #[track_caller]
     pub const fn from_static(src: &'static str) -> HeaderValue {
         let bytes = src.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
-            const_fn_assert::cfn_assert!(is_visible_ascii(bytes[i]));
+            if !is_visible_ascii(bytes[i]) {
+                ([] as [u8; 0])[0]; // Invalid header value
+            }
             i += 1;
         }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -57,12 +57,12 @@ impl HeaderValue {
     /// assert_eq!(val, "hello");
     /// ```
     #[inline]
-    pub fn from_static(src: &'static str) -> HeaderValue {
+    pub const fn from_static(src: &'static str) -> HeaderValue {
         let bytes = src.as_bytes();
-        for &b in bytes {
-            if !is_visible_ascii(b) {
-                panic!("invalid header value");
-            }
+        let mut i = 0;
+        while i < bytes.len() {
+            const_fn_assert::cfn_assert!(is_visible_ascii(bytes[i]));
+            i += 1;
         }
 
         HeaderValue {
@@ -555,7 +555,7 @@ mod try_from_header_name_tests {
     }
 }
 
-fn is_visible_ascii(b: u8) -> bool {
+const fn is_visible_ascii(b: u8) -> bool {
     b >= 32 && b < 127 || b == b'\t'
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -53,7 +53,7 @@ impl HeaderValue {
     /// makes its way into stable, the panic message at compile-time is
     /// going to look cryptic, but should at least point at your header value:
     ///
-    /// ```
+    /// ```text
     /// error: any use of this value will cause an error
     ///   --> http/src/header/value.rs:67:17
     ///    |

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -79,7 +79,6 @@ impl HeaderValue {
     /// ```
     #[inline]
     #[allow(unconditional_panic)] // required for the panic circumventon
-    #[track_caller]
     pub const fn from_static(src: &'static str) -> HeaderValue {
         let bytes = src.as_bytes();
         let mut i = 0;

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -49,6 +49,27 @@ impl HeaderValue {
     /// This function panics if the argument contains invalid header value
     /// characters.
     ///
+    /// Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345)
+    /// makes its way into stable, the panic message at compile-time is
+    /// going to look cryptic, but should at least point at your header value:
+    ///
+    /// ```
+    /// error: any use of this value will cause an error
+    ///   --> http/src/header/value.rs:67:17
+    ///    |
+    /// 67 |                 ([] as [u8; 0])[0]; // Invalid header value
+    ///    |                 ^^^^^^^^^^^^^^^^^^
+    ///    |                 |
+    ///    |                 index out of bounds: the length is 0 but the index is 0
+    ///    |                 inside `HeaderValue::from_static` at http/src/header/value.rs:67:17
+    ///    |                 inside `INVALID_HEADER` at src/main.rs:73:33
+    ///    |
+    ///   ::: src/main.rs:73:1
+    ///    |
+    /// 73 | const INVALID_HEADER: HeaderValue = HeaderValue::from_static("жsome value");
+    ///    | ----------------------------------------------------------------------------
+    /// ```
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
We have a few (lazy) statics for headers we reuse, e.g.

```rust
static HTTP_PROTO: Lazy<HeaderValue> = Lazy::new(|| HeaderValue::from_static("http"));
```

It dawned on me `HeaderValue::from_static` might be `const` with a few tweaks. With some help in avoiding the `panic!` (currently unstable, but [stabilization incoming](https://github.com/rust-lang/rust/issues/51999#issuecomment-823473542)), I was able to make it work.

This change would allow us to just write:

```rust
const HTTP_PROTO: HeaderValue = HeaderValue::from_static("http");
```

It doesn't give a nice panic like before, but if the user follows the backtrace, they should see the comment explaining that a panic here means they've provided an invalid header value.