### PR TITLE
Add author copyrights to the header map file

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1,3 +1,12 @@
+// Copyright 2017-2021 http-rs authors
+// Copyright 2016-2017 Ulrik Sverdrup "bluss", Piotr Czarnecki
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
 use std::convert::TryFrom;


### PR DESCRIPTION
The HeaderMap implementation as a whole is mostly orignal to http-rs,
but the implementation was based on and derived from the indexmap crate
(formerly ordermap) from circa 2017, from which the structure and many
methods were adapted. For this reason, mention the two indexmap authors
(one of them is me) from that time.

Fixes #489 