### PR TITLE
optionally support ahash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-fnv = "1.0.5"
 itoa = "0.4.1"
+fnv = { version = "1.0.5", optional = true }
+ahash = { version = "0.7", optional = true }
 
 [dev-dependencies]
 indexmap = "1.0"
@@ -34,6 +35,9 @@ seahash = "3.0.5"
 serde = "1.0"
 serde_json = "1.0"
 doc-comment = "0.3"
+
+[features]
+default = ["fnv"]
 
 [[bench]]
 name = "header_map"


### PR DESCRIPTION
aHash is known to be one of the most effective hash implemented on rust [see link](https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md). 

This PR introduces the optional usage of aHash instead of fnv hash. 

In my benchmark of HTTP server (hyper/warp) it shows ~1% in performance improvement overall. 

Alternatively we can fully migrate to aHash without introducing the feature, because it's the internal implementation details. 