### PR TITLE
Implement `AsHeaderName` for `Cow<'a, str>`

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -3358,6 +3358,8 @@ mod into_header_name {
 }
 
 mod as_header_name {
+    use std::borrow::Cow;
+
     use super::{Entry, HdrName, HeaderMap, HeaderName, InvalidHeaderName};
 
     /// A marker trait used to identify values that can be used as search keys
@@ -3489,6 +3491,27 @@ mod as_header_name {
     }
 
     impl<'a> AsHeaderName for &'a String {}
+
+    impl<'a> Sealed for Cow<'a, str> {
+        #[doc(hidden)]
+        #[inline]
+        fn try_entry<T>(self, map: &mut HeaderMap<T>) -> Result<Entry<'_, T>, InvalidHeaderName> {
+            self.as_str().try_entry(map)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        fn find<T>(&self, map: &HeaderMap<T>) -> Option<(usize, usize)> {
+            Sealed::find(&self.as_str(), map)
+        }
+
+        #[doc(hidden)]
+        fn as_str(&self) -> &str {
+            self
+        }
+    }
+
+    impl<'a> AsHeaderName for Cow<'a, str> {}
 }
 
 #[test]

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use http::header::*;
 use http::*;
 
@@ -258,6 +260,8 @@ fn as_header_name() {
     let s = String::from("host");
     assert_eq!(m.get(&s), expected);
     assert_eq!(m.get(s.as_str()), expected);
+    assert_eq!(m.get(Cow::Borrowed(s.as_str())), expected);
+    assert_eq!(m.get(Cow::Owned(s)), expected);
 }
 
 #[test]


### PR DESCRIPTION
This closes #285.