### PR TITLE
Add `Request::parts()` and `Request::parts_mut()`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@
 //! ```
 
 use std::any::Any;
-use std::convert::{TryFrom};
+use std::convert::TryFrom;
 use std::fmt;
 
 use crate::header::{HeaderMap, HeaderName, HeaderValue};
@@ -231,7 +231,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::GET).uri(uri)
     }
@@ -254,7 +253,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::PUT).uri(uri)
     }
@@ -277,7 +275,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::POST).uri(uri)
     }
@@ -300,7 +297,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::DELETE).uri(uri)
     }
@@ -324,7 +320,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::OPTIONS).uri(uri)
     }
@@ -347,7 +342,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::HEAD).uri(uri)
     }
@@ -370,7 +364,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::CONNECT).uri(uri)
     }
@@ -667,6 +660,35 @@ impl<T> Request<T> {
     #[inline]
     pub fn into_parts(self) -> (Parts, T) {
         (self.head, self.body)
+    }
+
+    /// Returns a reference to the request's head.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    /// let request = Request::new(());
+    /// assert_eq!(request.parts().method, Method::GET);
+    /// ```
+    #[inline]
+    pub fn parts(&self) -> &Parts {
+        &self.head
+    }
+
+    /// Returns a mutable reference to the request's head.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    /// let request = Request::new(());
+    /// request.parts_mut().method = Method::POST;
+    /// assert_eq!(request.method(), Method::POST);
+    /// ```
+    #[inline]
+    pub fn parts_mut(&self) -> &mut Parts {
+        &mut self.head
     }
 
     /// Consumes the request returning a new request with body mapped to the
@@ -1051,19 +1073,14 @@ impl Builder {
     ///     .unwrap();
     /// ```
     pub fn body<T>(self, body: T) -> Result<Request<T>> {
-        self.inner.map(move |head| {
-            Request {
-                head,
-                body,
-            }
-        })
+        self.inner.map(move |head| Request { head, body })
     }
 
     // private
 
     fn and_then<F>(self, func: F) -> Self
     where
-        F: FnOnce(Parts) -> Result<Parts>
+        F: FnOnce(Parts) -> Result<Parts>,
     {
         Builder {
             inner: self.inner.and_then(func),

--- a/src/request.rs
+++ b/src/request.rs
@@ -682,12 +682,12 @@ impl<T> Request<T> {
     ///
     /// ```
     /// # use http::*;
-    /// let request = Request::new(());
+    /// let mut request = Request::new(());
     /// request.parts_mut().method = Method::POST;
     /// assert_eq!(request.method(), Method::POST);
     /// ```
     #[inline]
-    pub fn parts_mut(&self) -> &mut Parts {
+    pub fn parts_mut(&mut self) -> &mut Parts {
         &mut self.head
     }
 


### PR DESCRIPTION
`http::Request::into_parts()` is the only way to access a request's
`Parts` structure.

It can be convenient to write utility code that takes a `&Parts` or
`&mut Parts`, i.e., so there's no need to parameterize the utility on
body type if it can't be used.

This change introduces accessors for the `Parts` structure so callers
need not use `Request::into_parts` and `Request::from_parts` to access
the `Parts` structure.

---

In service of https://github.com/tower-rs/tower-http/issues/154