### PR TITLE
Cargo: Add `rust-version` field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           - stable
           - beta
           - nightly
+          # When updating this value, don't forget to also adjust the
+          # `rust-version` field in the `Cargo.toml` file.
           - 1.46.0
 
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ A set of types for representing HTTP requests and responses.
 keywords = ["http"]
 categories = ["web-programming"]
 edition = "2018"
+# When updating this value, don't forget to also adjust the GitHub Actions config.
+rust-version = "1.46.0"
 
 [dependencies]
 bytes = "1"


### PR DESCRIPTION
see https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

This field defines the minimum supported Rust version. Since CI is explicitly checking against v1.46.0 I assumed that this was currently the intended minimum version.