### PR TITLE
deps: Update to itoa 1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.46.0"
 [dependencies]
 bytes = "1"
 fnv = "1.0.5"
-itoa = "0.4.1"
+itoa = "1"
 
 [dev-dependencies]
 indexmap = "1.0"

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -2,6 +2,7 @@ use bytes::{Bytes, BytesMut};
 
 use std::convert::TryFrom;
 use std::error::Error;
+use std::fmt::Write;
 use std::str::FromStr;
 use std::{cmp, fmt, mem, str};
 
@@ -427,7 +428,7 @@ macro_rules! from_integers {
                     // full value fits inline, so don't allocate!
                     BytesMut::new()
                 };
-                let _ = ::itoa::fmt(&mut buf, num);
+                let _ = buf.write_str(::itoa::Buffer::new().format(num));
                 HeaderValue {
                     inner: buf.freeze(),
                     is_sensitive: false,


### PR DESCRIPTION
In itoa 1, the interface has been slimmed down and the fmt method
is no longer present, so expand to the code that was there previously.