### PR TITLE
Enable simpler header name parser in debug builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      
+      - name: Test Release
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
 
       - name: Test all benches
         if: matrix.benches

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1039,7 +1039,7 @@ const HEADER_CHARS_H2: [u8; 256] = [
         0,     0,     0,     0,     0,     0                              // 25x
 ];
 
-#[cfg(any(not(debug_assertions), not(target_arch = "wasm32")))]
+#[cfg(all(not(debug_assertions), not(target_arch = "wasm32")))]
 macro_rules! eq {
     (($($cmp:expr,)*) $v:ident[$n:expr] ==) => {
         $($cmp) && *
@@ -1055,7 +1055,7 @@ macro_rules! eq {
     };
 }
 
-#[cfg(any(not(debug_assertions), not(target_arch = "wasm32")))]
+#[cfg(all(not(debug_assertions), not(target_arch = "wasm32")))]
 /// This version is best under optimized mode, however in a wasm debug compile,
 /// the `eq` macro expands to 1 + 1 + 1 + 1... and wasm explodes when this chain gets too long
 /// See https://github.com/DenisKolodin/yew/issues/478
@@ -1518,7 +1518,7 @@ fn parse_hdr<'a>(
     }
 }
 
-#[cfg(all(debug_assertions, target_arch = "wasm32"))]
+#[cfg(any(debug_assertions, target_arch = "wasm32"))]
 /// This version works best in debug mode in wasm
 fn parse_hdr<'a>(
     data: &'a [u8],

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1039,7 +1039,7 @@ const HEADER_CHARS_H2: [u8; 256] = [
         0,     0,     0,     0,     0,     0                              // 25x
 ];
 
-#[cfg(all(not(debug_assertions), not(target_arch = "wasm32")))]
+#[cfg(not(debug_assertions))]
 macro_rules! eq {
     (($($cmp:expr,)*) $v:ident[$n:expr] ==) => {
         $($cmp) && *
@@ -1055,7 +1055,7 @@ macro_rules! eq {
     };
 }
 
-#[cfg(all(not(debug_assertions), not(target_arch = "wasm32")))]
+#[cfg(not(debug_assertions))]
 /// This version is best under optimized mode, however in a wasm debug compile,
 /// the `eq` macro expands to 1 + 1 + 1 + 1... and wasm explodes when this chain gets too long
 /// See https://github.com/DenisKolodin/yew/issues/478
@@ -1518,7 +1518,7 @@ fn parse_hdr<'a>(
     }
 }
 
-#[cfg(any(debug_assertions, target_arch = "wasm32"))]
+#[cfg(debug_assertions)]
 /// This version works best in debug mode in wasm
 fn parse_hdr<'a>(
     data: &'a [u8],

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1056,9 +1056,8 @@ macro_rules! eq {
 }
 
 #[cfg(not(debug_assertions))]
-/// This version is best under optimized mode, however in a wasm debug compile,
-/// the `eq` macro expands to 1 + 1 + 1 + 1... and wasm explodes when this chain gets too long
-/// See https://github.com/DenisKolodin/yew/issues/478
+/// This version is best under optimized mode, however it generates a lot of
+/// code that adds ~1s to build times, so we only compile it for release builds.
 fn parse_hdr<'a>(
     data: &'a [u8],
     b: &'a mut [u8; 64],
@@ -1519,7 +1518,7 @@ fn parse_hdr<'a>(
 }
 
 #[cfg(debug_assertions)]
-/// This version works best in debug mode in wasm
+/// This version compiles faster for debug builds
 fn parse_hdr<'a>(
     data: &'a [u8],
     b: &'a mut [u8; 64],


### PR DESCRIPTION
This shaves close to a second off debug builds on my machine.