### PR TITLE
moved to finish_non_exhaustive in Debug impl

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -2010,7 +2010,7 @@ impl fmt::Debug for InvalidHeaderName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("InvalidHeaderName")
             // skip _priv noise
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -593,7 +593,7 @@ impl fmt::Debug for InvalidHeaderValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("InvalidHeaderValue")
             // skip _priv noise
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/method.rs
+++ b/src/method.rs
@@ -297,7 +297,7 @@ impl fmt::Debug for InvalidMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("InvalidMethod")
             // skip _priv noise
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -737,7 +737,7 @@ impl fmt::Debug for Parts {
             .field("headers", &self.headers)
             // omits Extensions because not useful
             // omits _priv because not useful
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -521,7 +521,7 @@ impl fmt::Debug for Parts {
             .field("headers", &self.headers)
             // omits Extensions because not useful
             // omits _priv because not useful
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -526,7 +526,7 @@ impl fmt::Debug for InvalidStatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("InvalidStatusCode")
             // skip _priv noise
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
This moves from the `finish` method to the `finish_non_exhaustive` method in Debug impl blocks where applicable.

"Marks the struct as non-exhaustive, indicating to the reader that there are some other fields that are not shown in the debug representation." - [std::fmt::DebugStruct Docs](https://doc.rust-lang.org/std/fmt/struct.DebugStruct.html#method.finish_non_exhaustive)