### PR TITLE
From impls of PathAndQuery and Authority for Uri

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -736,6 +736,28 @@ impl<'a> TryFrom<&'a Uri> for Uri {
     }
 }
 
+/// Convert an `Authority` into a `Uri`.
+impl From<Authority> for Uri {
+    fn from(authority: Authority) -> Self {
+        Self {
+            scheme: Scheme::empty(),
+            authority,
+            path_and_query: PathAndQuery::empty(),
+        }
+    }
+}
+
+/// Convert a `PathAndQuery` into a `Uri`.
+impl From<PathAndQuery> for Uri {
+    fn from(path_and_query: PathAndQuery) -> Self {
+        Self {
+            scheme: Scheme::empty(),
+            authority: Authority::empty(),
+            path_and_query,
+        }
+    }
+}
+
 /// Convert a `Uri` from parts
 ///
 /// # Examples

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -201,7 +201,40 @@ impl Uri {
         Builder::new()
     }
 
-    /// Attempt to convert a `Uri` from `Parts`
+    /// Attempt to convert a `Parts` into a `Uri`.
+    ///
+    /// # Examples
+    ///
+    /// Relative URI
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let mut parts = Parts::default();
+    /// parts.path_and_query = Some("/foo".parse().unwrap());
+    ///
+    /// let uri = Uri::from_parts(parts).unwrap();
+    ///
+    /// assert_eq!(uri.path(), "/foo");
+    ///
+    /// assert!(uri.scheme().is_none());
+    /// assert!(uri.authority().is_none());
+    /// ```
+    ///
+    /// Absolute URI
+    ///
+    /// ```
+    /// # use http::uri::*;
+    /// let mut parts = Parts::default();
+    /// parts.scheme = Some("http".parse().unwrap());
+    /// parts.authority = Some("foo.com".parse().unwrap());
+    /// parts.path_and_query = Some("/foo".parse().unwrap());
+    ///
+    /// let uri = Uri::from_parts(parts).unwrap();
+    ///
+    /// assert_eq!(uri.scheme().unwrap().as_str(), "http");
+    /// assert_eq!(uri.authority().unwrap(), "foo.com");
+    /// assert_eq!(uri.path(), "/foo");
+    /// ```
     pub fn from_parts(src: Parts) -> Result<Uri, InvalidUriParts> {
         if src.scheme.is_some() {
             if src.authority.is_none() {
@@ -758,40 +791,7 @@ impl From<PathAndQuery> for Uri {
     }
 }
 
-/// Convert a `Uri` from parts
-///
-/// # Examples
-///
-/// Relative URI
-///
-/// ```
-/// # use http::uri::*;
-/// let mut parts = Parts::default();
-/// parts.path_and_query = Some("/foo".parse().unwrap());
-///
-/// let uri = Uri::from_parts(parts).unwrap();
-///
-/// assert_eq!(uri.path(), "/foo");
-///
-/// assert!(uri.scheme().is_none());
-/// assert!(uri.authority().is_none());
-/// ```
-///
-/// Absolute URI
-///
-/// ```
-/// # use http::uri::*;
-/// let mut parts = Parts::default();
-/// parts.scheme = Some("http".parse().unwrap());
-/// parts.authority = Some("foo.com".parse().unwrap());
-/// parts.path_and_query = Some("/foo".parse().unwrap());
-///
-/// let uri = Uri::from_parts(parts).unwrap();
-///
-/// assert_eq!(uri.scheme().unwrap().as_str(), "http");
-/// assert_eq!(uri.authority().unwrap(), "foo.com");
-/// assert_eq!(uri.path(), "/foo");
-/// ```
+/// Convert a `Uri` into `Parts`
 impl From<Uri> for Parts {
     fn from(src: Uri) -> Self {
         let path_and_query = if src.has_path() {


### PR DESCRIPTION
A Uri may logically hold only an Authority or only a PathAndQuery.
Should an application want to make such Uris, it would be easier to
safely create them by first making just an Authority or just a
PathAndQuery, then cheaply convert them directly into a Uri.