### PR TITLE
update: export HeaderName from crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ mod extensions;
 pub use crate::error::{Error, Result};
 pub use crate::extensions::Extensions;
 #[doc(no_inline)]
-pub use crate::header::{HeaderMap, HeaderValue};
+pub use crate::header::{HeaderMap, HeaderName, HeaderValue};
 pub use crate::method::Method;
 pub use crate::request::Request;
 pub use crate::response::Response;


### PR DESCRIPTION
We already export `HeaderMap` and `HeaderValue` from the crate root, so why not `HeaderName`?