### PR TITLE
feat: Allow unicode in uri

### DIFF
--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -255,6 +255,18 @@ test_parse! {
 }
 
 test_parse! {
+    test_uri_parse_idna,
+    "https://www.fc-højvang.dk/",
+    [],
+
+    scheme = part!("https"),
+    authority = part!("www.fc-højvang.dk"),
+    path = "/",
+    query = None,
+    port = None,
+}
+
+test_parse! {
     test_userinfo1,
     "http://a:b@127.0.0.1:1234/",
     [],


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

Fix https://github.com/hyperium/http/issues/259

# Bench

## Before

```rust
test uri_parse_relative_medium ... bench:         128 ns/iter (+/- 12) = 468 MB/s
test uri_parse_relative_query  ... bench:         169 ns/iter (+/- 15) = 497 MB/s
test uri_parse_slash           ... bench:          32 ns/iter (+/- 0) = 31 MB/s
test uri_parse_full_query      missing, not supported
```

## After

```rust
test uri_parse_relative_medium ... bench:         153 ns/iter (+/- 4) = 392 MB/s
test uri_parse_relative_query  ... bench:         174 ns/iter (+/- 1) = 482 MB/s
test uri_parse_slash           ... bench:          28 ns/iter (+/- 0) = 35 MB/s
test uri_parse_full_query      ... bench:         293 ns/iter (+/- 15) = 293 MB/s
```

---

Our bench doesn't have `authority`, so those bench can't reflect the real perf