### PR TITLE
Add `Clone` for Request/Response/Extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ bytes = "1"
 fnv = "1.0.5"
 itoa = "1"
 
+anymap = "1.0.0-beta.2"
+
 [dev-dependencies]
 indexmap = "<=1.8"
 quickcheck = "0.9.0"
@@ -62,3 +64,6 @@ path = "benches/method.rs"
 [[bench]]
 name = "uri"
 path = "benches/uri.rs"
+
+[patch.crates-io]
+anymap = { git = "https://github.com/LucioFranco/anymap" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ mod error;
 mod extensions;
 
 pub use crate::error::{Error, Result};
-pub use crate::extensions::Extensions;
+pub use crate::extensions::{Extensions, NotCloneExtension};
 #[doc(no_inline)]
 pub use crate::header::{HeaderMap, HeaderName, HeaderValue};
 pub use crate::method::Method;

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@
 //! ```
 
 use std::any::Any;
-use std::convert::{TryFrom};
+use std::convert::TryFrom;
 use std::fmt;
 
 use crate::header::{HeaderMap, HeaderName, HeaderValue};
@@ -154,6 +154,7 @@ use crate::{Extensions, Result, Uri};
 /// #
 /// # fn main() {}
 /// ```
+#[derive(Clone)]
 pub struct Request<T> {
     head: Parts,
     body: T,
@@ -163,6 +164,7 @@ pub struct Request<T> {
 ///
 /// The HTTP request head consists of a method, uri, version, and a set of
 /// header fields.
+#[derive(Clone)]
 pub struct Parts {
     /// The request's method
     pub method: Method,
@@ -231,7 +233,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::GET).uri(uri)
     }
@@ -254,7 +255,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::PUT).uri(uri)
     }
@@ -277,7 +277,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::POST).uri(uri)
     }
@@ -300,7 +299,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::DELETE).uri(uri)
     }
@@ -324,7 +322,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::OPTIONS).uri(uri)
     }
@@ -347,7 +344,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::HEAD).uri(uri)
     }
@@ -370,7 +366,6 @@ impl Request<()> {
     where
         Uri: TryFrom<T>,
         <Uri as TryFrom<T>>::Error: Into<crate::Error>,
-
     {
         Builder::new().method(Method::CONNECT).uri(uri)
     }
@@ -987,7 +982,7 @@ impl Builder {
     /// ```
     pub fn extension<T>(self, extension: T) -> Builder
     where
-        T: Any + Send + Sync + 'static,
+        T: Any + Clone + Send + Sync + 'static,
     {
         self.and_then(move |mut head| {
             head.extensions.insert(extension);
@@ -1051,19 +1046,14 @@ impl Builder {
     ///     .unwrap();
     /// ```
     pub fn body<T>(self, body: T) -> Result<Request<T>> {
-        self.inner.map(move |head| {
-            Request {
-                head,
-                body,
-            }
-        })
+        self.inner.map(move |head| Request { head, body })
     }
 
     // private
 
     fn and_then<F>(self, func: F) -> Self
     where
-        F: FnOnce(Parts) -> Result<Parts>
+        F: FnOnce(Parts) -> Result<Parts>,
     {
         Builder {
             inner: self.inner.and_then(func),


### PR DESCRIPTION
# Proposal

Allow `Request<T>`/`Respnose<T>` to implement `Clone if T: Clone`. The current blocker for this is that `Extensions` doesn't implement `Clone`. This is due to the complicated nature of `Any` and `Clone`. Though it is a solvable problem shown by `dyn-clone` and the `anymap` (beta releases) crates.

The solution in this PR swaps out our own `AnyMap` implementation to use the `anymap` crate `1.0.0-beta.2` version that supports clonable values. The downside to this change is that it nows requires all the types that get inserted into the anymap to implement clone which is not a backwards compatible change and will break end users. To support this use case this PR adds a `NotCloneExtension` (pending name, open to ideas) that allows users to implement Clone for a type T that doesn't implement Clone. This is done by storing the inner type as an Option and when cloning the newtype it will set the value to None. This allows users to for example, have different extension instances per requests in the retry middleware.  

The benefit of `Request<T>`/`Response<T>` implementing clone will greatly improve the ergonomics for end users and simplify things like the tower retry layer.

Closes https://github.com/hyperium/http/issues/395

cc @seanmonstar @hawkw @davidbarsky @hlbarber @LukeMathWalker 


# Notes

This PR uses a forked version of the anymap crate that adds a specialized `extend_map` fn. The plan I think going forward would be to vendor the minimal set of code from the anymap crate and to not depend on it for 1.0 of http.