### PR TITLE
double quote "Sensitive" header value

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -368,7 +368,7 @@ impl AsRef<[u8]> for HeaderValue {
 impl fmt::Debug for HeaderValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_sensitive {
-            f.write_str("Sensitive")
+            f.write_str("\"Sensitive\"")
         } else {
             f.write_str("\"")?;
             let mut from = 0;
@@ -791,5 +791,5 @@ fn test_debug() {
 
     let mut sensitive = HeaderValue::from_static("password");
     sensitive.set_sensitive(true);
-    assert_eq!("Sensitive", format!("{:?}", sensitive));
+    assert_eq!("\"Sensitive\"", format!("{:?}", sensitive));
 }


### PR DESCRIPTION
In the implementation of `Debug` for `HeaderValue` if a value is not marked sensitive, the value is written to the formatter with double quotes added. However, if marked sensitive the unquoted static string `Sensitive` is instead written to the formatter. This causes issues when attempting to output headers during tracing/logging.

This PR adds double quotes to the "Sensitive" string output in the case of a sensitive `HeaderValue`.