### PR TITLE
docs: remove references to defunct `build` method

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -761,9 +761,6 @@ impl Builder {
 
     /// Set the HTTP method for this request.
     ///
-    /// This function will configure the HTTP method of the `Request` that will
-    /// be returned from `Builder::build`.
-    ///
     /// By default this is `GET`.
     ///
     /// # Examples
@@ -809,9 +806,6 @@ impl Builder {
 
     /// Set the URI for this request.
     ///
-    /// This function will configure the URI of the `Request` that will
-    /// be returned from `Builder::build`.
-    ///
     /// By default this is `/`.
     ///
     /// # Examples
@@ -855,9 +849,6 @@ impl Builder {
     }
 
     /// Set the HTTP version for this request.
-    ///
-    /// This function will configure the HTTP version of the `Request` that
-    /// will be returned from `Builder::build`.
     ///
     /// By default this is HTTP/1.1
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -546,9 +546,6 @@ impl Builder {
 
     /// Set the HTTP status for this response.
     ///
-    /// This function will configure the HTTP status code of the `Response` that
-    /// will be returned from `Builder::build`.
-    ///
     /// By default this is `200`.
     ///
     /// # Examples
@@ -573,9 +570,6 @@ impl Builder {
     }
 
     /// Set the HTTP version for this response.
-    ///
-    /// This function will configure the HTTP version of the `Response` that
-    /// will be returned from `Builder::build`.
     ///
     /// By default this is HTTP/1.1
     ///


### PR DESCRIPTION
Removes misleading instructions.

For `Response` and `Request` `Builder::body` is the consuming method, not `Builder::build`.

`Builder::build` was removed from request, and response never had it. [[ref commit](https://github.com/hyperium/http/commit/4bc29fb)]

# Criticism Welcome 😄 

Please let me know if I'm missing something obvious! 