### PR TITLE
Implement From<PathAndQuery> for Bytes

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -348,6 +348,12 @@ impl hash::Hash for PathAndQuery {
     }
 }
 
+impl From<PathAndQuery> for Bytes {
+    fn from(value: PathAndQuery) -> Self {
+        value.data.into()
+    }
+}
+
 // ===== PartialEq / PartialOrd =====
 
 impl PartialEq for PathAndQuery {


### PR DESCRIPTION
This allows getting a `Bytes` instance from a `PathAndQuery` without any copying.