### PR TITLE
Add optional serde support for top level types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Test
         run: cargo test
+        run: cargo test --all-features
 
       - name: Test all benches
         if: matrix.benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ exclude = [
 bytes = "1"
 fnv = "1.0.5"
 itoa = "1"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+serde1 = ["serde"]
 
 [dev-dependencies]
 indexmap = "<=1.8"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ fn main() {
 }
 ```
 
+## Serde
+
+Serde's `Serialize` and `Deserialize` traits are implemented for many types
+behind the `serde1` feature flag. Note that using this feature will increase
+the MSRV to 1.56.
+
+```toml
+[dependencies]
+http = { version = "0.2", features = ["serde1"] }
+```
+
 # Supported Rust Versions
 
 This project follows the [Tokio MSRV][msrv] and is currently set to `1.49`.

--- a/src/request.rs
+++ b/src/request.rs
@@ -154,6 +154,7 @@ use crate::{Extensions, Result, Uri};
 /// #
 /// # fn main() {}
 /// ```
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request<T> {
     head: Parts,
     body: T,
@@ -163,6 +164,7 @@ pub struct Request<T> {
 ///
 /// The HTTP request head consists of a method, uri, version, and a set of
 /// header fields.
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parts {
     /// The request's method
     pub method: Method,
@@ -177,8 +179,17 @@ pub struct Parts {
     pub headers: HeaderMap<HeaderValue>,
 
     /// The request's extensions
+    #[cfg_attr(
+        feature = "serde1",
+        serde(
+            skip_deserializing,
+            skip_serializing_if = "Extensions::is_empty",
+            serialize_with = "super::serde1::fail_serialize_extensions"
+        )
+    )]
     pub extensions: Extensions,
 
+    #[cfg_attr(feature = "serde1", serde(skip))]
     _priv: (),
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -176,6 +176,7 @@ use crate::{Extensions, Result};
 /// #
 /// # fn main() {}
 /// ```
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Response<T> {
     head: Parts,
     body: T,
@@ -185,6 +186,7 @@ pub struct Response<T> {
 ///
 /// The HTTP response head consists of a status, version, and a set of
 /// header fields.
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parts {
     /// The response's status
     pub status: StatusCode,
@@ -196,8 +198,17 @@ pub struct Parts {
     pub headers: HeaderMap<HeaderValue>,
 
     /// The response's extensions
+    #[cfg_attr(
+        feature = "serde1",
+        serde(
+            skip_deserializing,
+            skip_serializing_if = "Extensions::is_empty",
+            serialize_with = "super::serde1::fail_serialize_extensions"
+        )
+    )]
     pub extensions: Extensions,
 
+    #[cfg_attr(feature = "serde1", serde(skip))]
     _priv: (),
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -42,6 +42,11 @@ use std::str::FromStr;
 /// assert!(StatusCode::OK.is_success());
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "serde1",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "u16")
+)]
 pub struct StatusCode(NonZeroU16);
 
 /// A possible error value when converting a `StatusCode` from a `u16` or `&str`


### PR DESCRIPTION
This adds `serde::Serialize` and `serde::Deserialize` trait implementations for all types re-exported at the root level, except for `Extensions`, `Result`, and `Error`. `serde` is added as an optional dependency behind the feature flag `serde1`.

These are `HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode, Uri, Version, request::Parts, response::Parts`. Note for `Request` and `Response` it will fail serialization if `extensions` is non-empty, and will deserialize to a `Extensions::default()`.

Current workarounds are to use the `http_serde` crate, but that requires annotating `#[serde(with)]` and doesn't support using `Option` or other container types. Suggested alternatives are [quite complex](https://stackoverflow.com/questions/76143129/rust-serde-http-serialize-optionhttpmethod).

There was a previous attempt just for `StatusCode` in https://github.com/hyperium/http/pull/274 which seems to have gone stale.

Implements https://github.com/hyperium/http/issues/397, https://github.com/hyperium/http/issues/273, https://github.com/hyperium/http/issues/434