### PR TITLE
Override some provided `Iterator` methods for header map's `Keys`

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -2196,6 +2196,18 @@ impl<'a, T> Iterator for Keys<'a, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth(n).map(|b| &b.key)
+    }
+
+    fn count(self) -> usize {
+        self.inner.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.inner.last().map(|b| &b.key)
+    }
 }
 
 impl<'a, T> ExactSizeIterator for Keys<'a, T> {}


### PR DESCRIPTION
The `inner` iterator is simply a `slice::Iter`, so all of these can be done in constant time. Ideally, we would override `advance_by`, but that's still unstable.

With this, it is possible to build a poor man's `retain`, which was requested in #541. On that topic: would you be open to merge a PR adding `retain`? Then I might start working on that.