### PR TITLE
chore(lib): remove importing prelude AsRef trait

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -18,7 +18,6 @@
 use self::extension::{AllocatedExtension, InlineExtension};
 use self::Inner::*;
 
-use std::convert::AsRef;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::str::FromStr;


### PR DESCRIPTION
Removes importing prelude `AsRef` trait.