### PR TITLE
feat: add strict version of uri parsing

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -105,6 +105,81 @@ impl PathAndQuery {
         })
     }
 
+    /// Similar to [`from_shared`] but does not accept `{`, `}` and `"`
+    pub(super) fn from_shared_strict(mut src: Bytes) -> Result<Self, InvalidUri> {
+        let mut query = NONE;
+        let mut fragment = None;
+
+        // block for iterator borrow
+        {
+            let mut iter = src.as_ref().iter().enumerate();
+
+            // path ...
+            for (i, &b) in &mut iter {
+                // See https://url.spec.whatwg.org/#path-state
+                match b {
+                    b'?' => {
+                        debug_assert_eq!(query, NONE);
+                        query = i as u16;
+                        break;
+                    }
+                    b'#' => {
+                        fragment = Some(i);
+                        break;
+                    }
+
+                    // This is the range of bytes that don't need to be
+                    // percent-encoded in the path. If it should have been
+                    // percent-encoded, then error.
+                    #[rustfmt::skip]
+                    0x21 |
+                    0x24..=0x3B |
+                    0x3D |
+                    0x40..=0x5F |
+                    0x61..=0x7A |
+                    0x7C |
+                    0x7E => {}
+
+                    _ => return Err(ErrorKind::InvalidUriChar.into()),
+                }
+            }
+
+            // query ...
+            if query != NONE {
+                for (i, &b) in iter {
+                    match b {
+                        // While queries *should* be percent-encoded, most
+                        // bytes are actually allowed...
+                        // See https://url.spec.whatwg.org/#query-state
+                        //
+                        // Allowed: 0x21 / 0x24 - 0x3B / 0x3D / 0x3F - 0x7E
+                        #[rustfmt::skip]
+                        0x21 |
+                        0x24..=0x3B |
+                        0x3D |
+                        0x3F..=0x7E => {}
+
+                        b'#' => {
+                            fragment = Some(i);
+                            break;
+                        }
+
+                        _ => return Err(ErrorKind::InvalidUriChar.into()),
+                    }
+                }
+            }
+        }
+
+        if let Some(i) = fragment {
+            src.truncate(i);
+        }
+
+        Ok(PathAndQuery {
+            data: unsafe { ByteStr::from_utf8_unchecked(src) },
+            query,
+        })
+    }
+
     /// Convert a `PathAndQuery` from a static string.
     ///
     /// This function will not perform any copying, however the string is
@@ -562,6 +637,12 @@ mod tests {
             r#"/{"bread":"baguette"}"#,
             pq(r#"/{"bread":"baguette"}"#).path()
         );
+    }
+
+    #[test]
+    fn fails_json_on_strict() {
+        let pq_bytes = r#"/{"bread":"baguette"}"#.as_bytes();
+        PathAndQuery::from_shared_strict(pq_bytes.into()).expect_err("should err");
     }
 
     fn pq(s: &str) -> PathAndQuery {


### PR DESCRIPTION
This PR adds a strict version of uri parsing to disallow `{`, `}` and `"`.

See https://github.com/hyperium/hyper/issues/3594