### PR TITLE
Allow empty authority in absolute URIs

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -862,11 +862,6 @@ fn parse_full(mut s: Bytes) -> Result<Uri, InvalidUri> {
         });
     }
 
-    // Authority is required when absolute
-    if authority_end == 0 {
-        return Err(ErrorKind::InvalidFormat.into());
-    }
-
     let authority = s.split_to(authority_end);
     let authority = Authority {
         data: unsafe { ByteStr::from_utf8_unchecked(authority) },

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -385,6 +385,19 @@ test_parse! {
 }
 
 test_parse! {
+    test_file_no_host,
+    "file:///some/path",
+    [],
+
+    scheme = part!("file"),
+    authority = None,
+    host = None,
+    path = "/some/path",
+    query = None,
+    port = None,
+}
+
+test_parse! {
     test_percentage_encoded_path,
     "/echo/abcdefgh_i-j%20/abcdefg_i-j%20478",
     [],
@@ -419,7 +432,6 @@ fn test_uri_parse_error() {
         Uri::from_str(s).unwrap_err();
     }
 
-    err("http://");
     err("htt:p//host");
     err("hyper.rs/");
     err("hyper.rs?key=val");


### PR DESCRIPTION
Fixes #323 

This removes the restriction preventing empty `authority` in URIs.  The canonical example of this is `file:///` which has a zero-length authority.  While these may not be relevant for a web server, there are many domains that need these sorts of alternative URIs (for example Webview-based software which reads local resources).

https://datatracker.ietf.org/doc/html/rfc3986 pretty clearly describes the authority as optional in all situations AFAICT, but it mentions that schema-specific restrictions may be in place.

This is the case for HTTP addresses, described in https://www.rfc-editor.org/rfc/rfc9110.html#name-identifiers-in-http
> The origin server for an "https" URI is identified by the [authority](https://www.rfc-editor.org/rfc/rfc9110.html#uri.references) component
...
> A sender MUST NOT generate an "https" URI with an empty host identifier. A recipient that processes such a URI reference MUST reject it as invalid.

It's possible that some users of this library in a strictly-http context may be relying on this checking the validity of the HTTP identifier for them.  I'm not sure how to handle this, maybe with a version bump? The legacy behavior could be considered a bug though.

Eventually a separate HttpUri type or something that performs the additional checks when constructed might be useful.