### PR TITLE
feat(status-code): `impl Deref for StatusCode` to read the inner value

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -18,6 +18,7 @@ use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU16;
+use std::ops::Deref;
 use std::str::FromStr;
 
 /// An HTTP status code (`status-code` in RFC 9110 et al.).
@@ -232,6 +233,14 @@ impl Default for StatusCode {
     #[inline]
     fn default() -> StatusCode {
         StatusCode::OK
+    }
+}
+
+impl Deref for StatusCode {
+    type Target = NonZeroU16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/tests/status_code.rs
+++ b/tests/status_code.rs
@@ -1,4 +1,5 @@
 use http::*;
+use std::num::NonZeroU16;
 
 #[test]
 fn from_bytes() {
@@ -76,7 +77,14 @@ fn is_server_error() {
     assert!(!status_code(600).is_server_error());
 }
 
+#[test]
+fn deref() {
+    let status_code = StatusCode::OK;
+    assert_eq!(*status_code, NonZeroU16::new(200).unwrap());
+}
+
 /// Helper method for readability
 fn status_code(status_code: u16) -> StatusCode {
     StatusCode::from_u16(status_code).unwrap()
 }
+


### PR DESCRIPTION
With this PR, it is possible to access the inner `NonzeroU16` value without modifying it. This avoids `NonZeroU16::try_from(status_code.as_u16()).unwrap()`, which introduces a panic, which will be optimised away by the compiler, but e.g. clippy might complain about a missing `# Panic`-section in the documentation. Due to `impl Copy for NonZeroU16`, one can simply convert `StatusCode` to `NonZeroU16`. `DerefMut` was not implemented, because this would make the range-check useless.