### PR TITLE
refactor(name): simplify `uninit_u8_array`

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1654,10 +1654,7 @@ const SCRATCH_BUF_SIZE: usize = 64;
 const SCRATCH_BUF_OVERFLOW: usize = SCRATCH_BUF_SIZE + 1;
 
 fn uninit_u8_array() -> [MaybeUninit<u8>; SCRATCH_BUF_SIZE] {
-    let arr = MaybeUninit::<[MaybeUninit<u8>; SCRATCH_BUF_SIZE]>::uninit();
-    // Safety: assume_init() is claiming that an array of MaybeUninit<>
-    // has been initilized, but MaybeUninit<>'s do not require initilizaton.
-    unsafe { arr.assume_init() }
+    [MaybeUninit::<u8>::uninit(); SCRATCH_BUF_SIZE]
 }
 
 // Assuming all the elements are initilized, get a slice of them.


### PR DESCRIPTION
The codegen seems to be OK: https://godbolt.org/z/da5Psn1s9
- Just us good (noop) on O1+.
- Even smaller (and with just 1 memset instead of 3 memcpy's) on O0.

Bonus point: no need for unsafe (because, as everyone knows, unsafe=bad, Rust=good, hehe).