### PR TITLE
refactor(lib): use `#[non_exhaustive]`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -165,6 +165,7 @@ pub struct Request<T> {
 /// The HTTP request head consists of a method, uri, version, and a set of
 /// header fields.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Parts {
     /// The request's method
     pub method: Method,
@@ -180,8 +181,6 @@ pub struct Parts {
 
     /// The request's extensions
     pub extensions: Extensions,
-
-    _priv: (),
 }
 
 /// An HTTP request builder
@@ -715,7 +714,6 @@ impl Parts {
             version: Version::default(),
             headers: HeaderMap::default(),
             extensions: Extensions::default(),
-            _priv: (),
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -187,6 +187,7 @@ pub struct Response<T> {
 /// The HTTP response head consists of a status, version, and a set of
 /// header fields.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Parts {
     /// The response's status
     pub status: StatusCode,
@@ -199,8 +200,6 @@ pub struct Parts {
 
     /// The response's extensions
     pub extensions: Extensions,
-
-    _priv: (),
 }
 
 /// An HTTP response builder
@@ -507,7 +506,6 @@ impl Parts {
             version: Version::default(),
             headers: HeaderMap::default(),
             extensions: Extensions::default(),
-            _priv: (),
         }
     }
 }

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -103,6 +103,7 @@ pub struct Uri {
 ///
 /// This struct is used to provide to and retrieve from a URI.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct Parts {
     /// The scheme component of a URI
     pub scheme: Option<Scheme>,
@@ -112,9 +113,6 @@ pub struct Parts {
 
     /// The origin-form component of a URI
     pub path_and_query: Option<PathAndQuery>,
-
-    /// Allow extending in the future
-    _priv: (),
 }
 
 /// An error resulting from a failed attempt to construct a URI.
@@ -814,7 +812,6 @@ impl From<Uri> for Parts {
             scheme,
             authority,
             path_and_query,
-            _priv: (),
         }
     }
 }


### PR DESCRIPTION
This seems to be supported starting with 1.40 (the MSRV is 1.48) and accomplishes the exact same functionality.

Got caught by clippy btw.