### PR TITLE
Skip checking twice for non-zero status code in `StatusCode::from_u16`

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -75,9 +75,9 @@ impl StatusCode {
             return Err(InvalidStatusCode::new());
         }
 
-        NonZeroU16::new(src)
-            .map(StatusCode)
-            .ok_or_else(InvalidStatusCode::new)
+        // SAFETY: We just checked that src is non-zero
+        let code = unsafe { NonZeroU16::new_unchecked(src) };
+        Ok(StatusCode(code))
     }
 
     /// Converts a &[u8] to a status code


### PR DESCRIPTION
See this code snippet, `status.rs` lines `72-81`:

```rs
    #[inline]
    pub fn from_u16(src: u16) -> Result<StatusCode, InvalidStatusCode> {
        if !(100..1000).contains(&src) {
            return Err(InvalidStatusCode::new());
        }

        NonZeroU16::new(src)
            .map(StatusCode)
            .ok_or_else(InvalidStatusCode::new)
    }
```

Here, we use the safe API `NonZeroU16::new` to create the `StatusCode`, but we have already done a check that our code is at least 100 (and thus already non-zero). We should change this to use `NonZeroU16::new_unchecked`, which skips the zero check. It also makes it easier for the compiler to figure out that it is a very trivial operation, and will make the code run slightly faster in debug builds. (For optimised builds, the compiler seems to figure out that the second check is not needed anyways, [as far as I can see](https://godbolt.org/z/xqYhPxjjz) ). The `new_unchecked` API is way older than MSRV (1.28.0) and has been const ever since.

I suggest we change this to use the unsafe API:

```rs
    #[inline]
    pub fn from_u16(src: u16) -> Result<StatusCode, InvalidStatusCode> {
        if !(100..1000).contains(&src) {
            return Err(InvalidStatusCode::new());
        }

        // SAFETY: We just checked that src is non-zero
        let code = unsafe { NonZeroU16::new_unchecked(src) };
        Ok(StatusCode(code))
    }
```