### PR TITLE
fix: off by 1 error in Method::from_bytes

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -466,17 +466,19 @@ mod test {
         let long_method = "This_is_a_very_long_method.It_is_valid_but_unlikely.";
         assert_eq!(Method::from_str(long_method).unwrap(), long_method);
 
-        // if these two assert_eq! fail, the output message may not be helpful, because type info
-        // of Method.Inner is not printed
         let longest_inline_method = [b'A'; InlineExtension::MAX];
         assert_eq!(
             Method::from_bytes(&longest_inline_method).unwrap(),
-            Method(ExtensionInline(InlineExtension::new(&longest_inline_method).unwrap()))
+            Method(ExtensionInline(
+                InlineExtension::new(&longest_inline_method).unwrap()
+            ))
         );
         let shortest_allocated_method = [b'A'; InlineExtension::MAX + 1];
         assert_eq!(
             Method::from_bytes(&shortest_allocated_method).unwrap(),
-            Method(ExtensionAllocated(AllocatedExtension::new(&shortest_allocated_method).unwrap()))
+            Method(ExtensionAllocated(
+                AllocatedExtension::new(&shortest_allocated_method).unwrap()
+            ))
         );
     }
 }

--- a/src/method.rs
+++ b/src/method.rs
@@ -123,7 +123,7 @@ impl Method {
                 _ => Method::extension_inline(src),
             },
             _ => {
-                if src.len() < InlineExtension::MAX {
+                if src.len() <= InlineExtension::MAX {
                     Method::extension_inline(src)
                 } else {
                     let allocated = AllocatedExtension::new(src)?;
@@ -465,5 +465,18 @@ mod test {
 
         let long_method = "This_is_a_very_long_method.It_is_valid_but_unlikely.";
         assert_eq!(Method::from_str(long_method).unwrap(), long_method);
+
+        // if these two assert_eq! fail, the output message may not be helpful, because type info
+        // of Method.Inner is not printed
+        let longest_inline_method = [b'A'; InlineExtension::MAX];
+        assert_eq!(
+            Method::from_bytes(&longest_inline_method).unwrap(),
+            Method(ExtensionInline(InlineExtension::new(&longest_inline_method).unwrap()))
+        );
+        let shortest_allocated_method = [b'A'; InlineExtension::MAX + 1];
+        assert_eq!(
+            Method::from_bytes(&shortest_allocated_method).unwrap(),
+            Method(ExtensionAllocated(AllocatedExtension::new(&shortest_allocated_method).unwrap()))
+        );
     }
 }


### PR DESCRIPTION
I'm not very sure if this is a error, and if not, please just ignore. If so, i think fixing it is meaningful, because when reading the code, readers may verify these `if/else` logic in mind and take time to find answer, this is my personal experience and is the most important reason for this PR.