### PR TITLE
Allow characters `#`, `$`, `%`, `&`, `'` in HTTP method

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -356,7 +356,7 @@ mod extension {
         }
     }
 
-    // From the HTTP spec section 5.1.1, the HTTP method is case-sensitive and can
+    // From the RFC 9110 HTTP Semantics, section 9.1, the HTTP method is case-sensitive and can
     // contain the following characters:
     //
     // ```
@@ -366,7 +366,7 @@ mod extension {
     //     "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     // ```
     //
-    // https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Method
+    // https://datatracker.ietf.org/doc/html/rfc9110#section-9.1
     //
     // Note that this definition means that any &[u8] that consists solely of valid
     // characters is also valid UTF-8 because the valid method characters are a

--- a/src/method.rs
+++ b/src/method.rs
@@ -377,7 +377,7 @@ mod extension {
         b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', //   x
         b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', //  1x
         b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', //  2x
-        b'\0', b'\0', b'\0',  b'!', b'\0', b'\0', b'\0', b'\0', b'\0', b'\0', //  3x
+        b'\0', b'\0', b'\0',  b'!', b'\0',  b'#',  b'$',  b'%',  b'&', b'\'', //  3x
         b'\0', b'\0',  b'*',  b'+', b'\0',  b'-',  b'.', b'\0',  b'0',  b'1', //  4x
          b'2',  b'3',  b'4',  b'5',  b'6',  b'7',  b'8',  b'9', b'\0', b'\0', //  5x
         b'\0', b'\0', b'\0', b'\0', b'\0',  b'A',  b'B',  b'C',  b'D',  b'E', //  6x
@@ -465,5 +465,21 @@ mod test {
 
         let long_method = "This_is_a_very_long_method.It_is_valid_but_unlikely.";
         assert_eq!(Method::from_str(long_method).unwrap(), long_method);
+    }
+
+    #[test]
+    fn test_extension_method_chars() {
+        const VALID_METHOD_CHARS: &str =
+            "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        for c in VALID_METHOD_CHARS.chars() {
+            let c = c.to_string();
+
+            assert_eq!(
+                Method::from_str(&c).unwrap(),
+                c.as_str(),
+                "testing {c} is a valid method character"
+            );
+        }
     }
 }


### PR DESCRIPTION
This PR adds those missing characters to `http::method::extension::METHOD_CHARS` and updates its comment to reference RFC 9110.