### PR TITLE
feat(path-and-query): allow utf8 char, not rfc 3986 compliant, in path and query

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -50,7 +50,7 @@ impl PathAndQuery {
                     0x40..=0x5F |
                     0x61..=0x7A |
                     0x7C |
-                    0x7E => {}
+                    0x7E..=0xFF => {}
 
                     // These are code points that are supposed to be
                     // percent-encoded in the path but there are clients
@@ -82,7 +82,7 @@ impl PathAndQuery {
                         0x21 |
                         0x24..=0x3B |
                         0x3D |
-                        0x3F..=0x7E => {}
+                        0x3F..=0xFF => {}
 
                         b'#' => {
                             fragment = Some(i);
@@ -554,6 +554,16 @@ mod tests {
         assert_eq!("/aa%2", pq("/aa%2").path());
         assert_eq!("/aa%2", pq("/aa%2?r=1").path());
         assert_eq!("qr=%3", pq("/a/b?qr=%3").query().unwrap());
+    }
+
+    #[test]
+    fn allow_utf8_in_path() {
+        assert_eq!("/🍕", pq("/🍕").path());
+    }
+
+    #[test]
+    fn allow_utf8_in_query() {
+        assert_eq!(Some("pizza=🍕"), pq("/test?pizza=🍕").query());
     }
 
     #[test]


### PR DESCRIPTION
This is a follow up of a PR in https://github.com/seanmonstar/httparse/pull/178 

This is mainly to allow incoming request that may have utf8 char in their path or query as some browsers send them raw instead of doing a percent encode (see the details here : https://github.com/actix/actix-web/issues/3102#issuecomment-1676454659 for a list of browser doing that)

This patch allow to correctly build a request object based on this behavior

I made it simple for the moment as i don't know how you want to handle this, in a feature flag ? through an option ? neither of them ?

Also i don't know on which version this should be based, it seems that 0.2 still receive some support should it be backported to this version also ?
