### PR TITLE
feat: add support for HTTP QUERY method

### DIFF
--- a/benches/src/method.rs
+++ b/benches/src/method.rs
@@ -16,6 +16,7 @@ fn make_all_methods() -> Vec<Vec<u8>> {
         b"TRACE".to_vec(),
         b"CONNECT".to_vec(),
         b"PATCH".to_vec(),
+        b"QUERY".to_vec(),
         b"CUSTOM_SHORT".to_vec(),
         b"CUSTOM_LONG_METHOD".to_vec(),
     ]

--- a/src/method.rs
+++ b/src/method.rs
@@ -30,7 +30,7 @@ use std::{fmt, str};
 ///
 /// Currently includes 8 variants representing the 8 methods defined in
 /// [RFC 7230](https://tools.ietf.org/html/rfc7231#section-4.1), plus PATCH,
-/// and an Extension variant for all extensions.
+/// QUERY, and an Extension variant for all extensions.
 ///
 /// # Examples
 ///
@@ -60,6 +60,7 @@ enum Inner {
     Trace,
     Connect,
     Patch,
+    Query,
     // If the extension is short enough, store it inline
     ExtensionInline(InlineExtension),
     // Otherwise, allocate it
@@ -94,6 +95,9 @@ impl Method {
     /// TRACE
     pub const TRACE: Method = Method(Trace);
 
+    /// QUERY
+    pub const QUERY: Method = Method(Query);
+
     /// Converts a slice of bytes to an HTTP method.
     pub fn from_bytes(src: &[u8]) -> Result<Method, InvalidMethod> {
         match src.len() {
@@ -111,6 +115,7 @@ impl Method {
             5 => match src {
                 b"PATCH" => Ok(Method(Patch)),
                 b"TRACE" => Ok(Method(Trace)),
+                b"QUERY" => Ok(Method(Query)),
                 _ => Method::extension_inline(src),
             },
             6 => match src {
@@ -146,7 +151,7 @@ impl Method {
     /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.1)
     /// for more words.
     pub fn is_safe(&self) -> bool {
-        matches!(self.0, Get | Head | Options | Trace)
+        matches!(self.0, Get | Head | Options | Trace | Query)
     }
 
     /// Whether a method is considered "idempotent", meaning the request has
@@ -174,6 +179,7 @@ impl Method {
             Trace => "TRACE",
             Connect => "CONNECT",
             Patch => "PATCH",
+            Query => "QUERY",
             ExtensionInline(ref inline) => inline.as_str(),
             ExtensionAllocated(ref allocated) => allocated.as_str(),
         }
@@ -452,6 +458,7 @@ mod test {
         assert!(Method::DELETE.is_idempotent());
         assert!(Method::HEAD.is_idempotent());
         assert!(Method::TRACE.is_idempotent());
+        assert!(Method::QUERY.is_idempotent());
 
         assert!(!Method::POST.is_idempotent());
         assert!(!Method::CONNECT.is_idempotent());

--- a/src/request.rs
+++ b/src/request.rs
@@ -413,6 +413,28 @@ impl Request<()> {
     {
         Builder::new().method(Method::TRACE).uri(uri)
     }
+
+    /// Creates a new `Builder` initialized with a QUERY method and the given URI.
+    ///
+    /// This method returns an instance of `Builder` which can be used to
+    /// create a `Request`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::*;
+    ///
+    /// let request = Request::query("https://www.rust-lang.org/")
+    ///     .body(())
+    ///     .unwrap();
+    /// ```
+    pub fn query<T>(uri: T) -> Builder
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<crate::Error>,
+    {
+        Builder::new().method(Method::QUERY).uri(uri)
+    }
 }
 
 impl<T> Request<T> {


### PR DESCRIPTION
The HTTP QUERY method is a means of making a safe, idempotent request that contains content. The primary motivator for this case is graphql, replacing HTTP POST for read only requests, however it is application agnostic.

This method is still in draft but stable enough where it is unlikely to change for this implementation.

https://httpwg.org/http-extensions/draft-ietf-httpbis-safe-method-w-body.html