### PR TITLE
Generalize HeaderMap's TryFrom impl from HashMap, to allow other hashing algorithms

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -2020,7 +2020,7 @@ impl<T> FromIterator<(HeaderName, T)> for HeaderMap<T> {
 /// let headers: HeaderMap = (&map).try_into().expect("valid headers");
 /// assert_eq!(headers["X-Custom-Header"], "my value");
 /// ```
-impl<'a, K, V, T> TryFrom<&'a HashMap<K, V>> for HeaderMap<T>
+impl<'a, K, V, S, T> TryFrom<&'a HashMap<K, V, S>> for HeaderMap<T>
 where
     K: Eq + Hash,
     HeaderName: TryFrom<&'a K>,
@@ -2030,7 +2030,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(c: &'a HashMap<K, V>) -> Result<Self, Self::Error> {
+    fn try_from(c: &'a HashMap<K, V, S>) -> Result<Self, Self::Error> {
         c.iter()
             .map(|(k, v)| -> crate::Result<(HeaderName, T)> {
                 let name = TryFrom::try_from(k).map_err(Into::into)?;


### PR DESCRIPTION
Instead of `impl TryFrom<&'a HashMap<K, V>> for HeaderMap<T>` this PR changes this to `impl TryFrom<&'a HashMap<K, V, S>> for HeaderMap<T>`.
No change in behaviour, it only makes the input type more general so it allows passing hashmaps with other hashing functions as well.

This change is fully backwards-compatible because of the no-orphans rule.

Fixes #726