### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = ["http"]
 categories = ["web-programming"]
 edition = "2018"
 # When updating this value, don't forget to also adjust the GitHub Actions config.
-rust-version = "1.49.0"
+rust-version = "1.70.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
 
 # Supported Rust Versions
 
-This project follows the [Tokio MSRV][msrv] and is currently set to `1.49`.
+This project follows the [Tokio MSRV][msrv] and is currently set to `1.70`.
 
 [msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions
 

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1205,27 +1205,6 @@ impl HeaderName {
     ///
     /// This function panics when the static string is a invalid header.
     ///
-    /// Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345)
-    /// makes its way into stable, the panic message at compile-time is
-    /// going to look cryptic, but should at least point at your header value:
-    ///
-    /// ```text
-    /// error: any use of this value will cause an error
-    ///     --> http/src/header/name.rs:1241:13
-    ///      |
-    /// 1241 |             ([] as [u8; 0])[0]; // Invalid header name
-    ///      |             ^^^^^^^^^^^^^^^^^^
-    ///      |             |
-    ///      |             index out of bounds: the length is 0 but the index is 0
-    ///      |             inside `http::HeaderName::from_static` at http/src/header/name.rs:1241:13
-    ///      |             inside `INVALID_NAME` at src/main.rs:3:34
-    ///      |
-    ///     ::: src/main.rs:3:1
-    ///      |
-    /// 3    | const INVALID_NAME: HeaderName = HeaderName::from_static("Capitalized");
-    ///      | ------------------------------------------------------------------------
-    /// ```
-    ///
     /// # Examples
     ///
     /// ```
@@ -1272,13 +1251,7 @@ impl HeaderName {
                 i += 1;
             }
         } {
-            // TODO: When msrv is bumped to larger than 1.57, this should be
-            // replaced with `panic!` macro.
-            // https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts
-            //
-            // See the panics section of this method's document for details.
-            #[allow(clippy::no_effect, clippy::out_of_bounds_indexing)]
-            ([] as [u8; 0])[0]; // Invalid header name
+            panic!("Invalid header name");
         }
 
         HeaderName {

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -51,27 +51,6 @@ impl HeaderValue {
     /// This function panics if the argument contains invalid header value
     /// characters.
     ///
-    /// Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345)
-    /// makes its way into stable, the panic message at compile-time is
-    /// going to look cryptic, but should at least point at your header value:
-    ///
-    /// ```text
-    /// error: any use of this value will cause an error
-    ///   --> http/src/header/value.rs:67:17
-    ///    |
-    /// 67 |                 ([] as [u8; 0])[0]; // Invalid header value
-    ///    |                 ^^^^^^^^^^^^^^^^^^
-    ///    |                 |
-    ///    |                 index out of bounds: the length is 0 but the index is 0
-    ///    |                 inside `HeaderValue::from_static` at http/src/header/value.rs:67:17
-    ///    |                 inside `INVALID_HEADER` at src/main.rs:73:33
-    ///    |
-    ///   ::: src/main.rs:73:1
-    ///    |
-    /// 73 | const INVALID_HEADER: HeaderValue = HeaderValue::from_static("жsome value");
-    ///    | ----------------------------------------------------------------------------
-    /// ```
-    ///
     /// # Examples
     ///
     /// ```
@@ -86,13 +65,7 @@ impl HeaderValue {
         let mut i = 0;
         while i < bytes.len() {
             if !is_visible_ascii(bytes[i]) {
-                // TODO: When msrv is bumped to larger than 1.57, this should be
-                // replaced with `panic!` macro.
-                // https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts
-                //
-                // See the panics section of this method's document for details.
-                #[allow(clippy::no_effect, clippy::out_of_bounds_indexing)]
-                ([] as [u8; 0])[0]; // Invalid header value
+                panic!("Invalid header value");
             }
             i += 1;
         }


### PR DESCRIPTION
This project follows Tokio MSRV which is now at 1.70.
Additionally, this allows to use panic in constant to simplify some code.