### PR TITLE
enhancement: return static reference from `StatusCode::as_str`

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -132,7 +132,7 @@ impl StatusCode {
     /// assert_eq!(status.as_str(), "200");
     /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         let offset = (self.0.get() - 100) as usize;
         let offset = offset * 3;
 


### PR DESCRIPTION
As stated in the PR title.

No reason to not have it be a static string reference.