### PR TITLE
Allow non-percent-encoded spaces in path

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -44,7 +44,7 @@ impl PathAndQuery {
                     // percent-encoded in the path. If it should have been
                     // percent-encoded, then error.
                     #[rustfmt::skip]
-                    0x21 |
+                    0x20..=0x21 |
                     0x24..=0x3B |
                     0x3D |
                     0x40..=0x5F |
@@ -559,6 +559,11 @@ mod tests {
     #[test]
     fn allow_utf8_in_path() {
         assert_eq!("/🍕", pq("/🍕").path());
+    }
+
+    #[test]
+    fn allow_space_in_path() {
+        assert_eq!("/dav/With Space/", pq("/dav/With Space/").path());
     }
 
     #[test]


### PR DESCRIPTION
The space character is not a reserved character. While it MAY be used in percent-encoded form, this is not mandatory and it is acceptable to use raw spaces in URL paths.

Add Space (0x20) to the list of characters that don't need to be percent-encoded.