### PR TITLE
`no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/http"
 repository = "https://github.com/hyperium/http"
 license = "MIT OR Apache-2.0"
 authors = [
-  "Alex Crichton <alex@alexcrichton.com>",
-  "Carl Lerche <me@carllerche.com>",
-  "Sean McArthur <sean@seanmonstar.com>",
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Carl Lerche <me@carllerche.com>",
+    "Sean McArthur <sean@seanmonstar.com>",
 ]
 description = """
 A set of types for representing HTTP requests and responses.
@@ -25,19 +25,21 @@ rust-version = "1.49.0"
 
 [workspace]
 members = [
-  ".",
+    ".",
 ]
 exclude = [
-  "fuzz",
-  "benches"
+    "fuzz",
+    "benches"
 ]
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = ["dep:bytes", "dep:hashbrown"]
 
 [dependencies]
-bytes = "1"
+bytes = { version = "1", optional = true }
+hashbrown = { version = "0.15", optional = true }
 fnv = "1.0.5"
 itoa = "1"
 
@@ -47,3 +49,11 @@ rand = "0.8.0"
 serde = "1.0"
 serde_json = "1.0"
 doc-comment = "0.3"
+
+[[test]]
+name = "header_map_fuzz"
+required-features = ["alloc"]
+
+[[test]]
+name = "header_map"
+required-features = ["alloc"]

--- a/src/byte_str.rs
+++ b/src/byte_str.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-use std::{ops, str};
+use core::{ops, str};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct ByteStr {
@@ -58,9 +58,9 @@ impl ops::Deref for ByteStr {
     }
 }
 
-impl From<String> for ByteStr {
+impl From<alloc::string::String> for ByteStr {
     #[inline]
-    fn from(src: String) -> ByteStr {
+    fn from(src: alloc::string::String) -> ByteStr {
         ByteStr {
             // Invariant: src is a String so contains valid UTF-8.
             bytes: Bytes::from(src),

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,11 +1,12 @@
+#[cfg(feature = "alloc")]
 macro_rules! if_downcast_into {
     ($in_ty:ty, $out_ty:ty, $val:ident, $body:expr) => {{
-        if std::any::TypeId::of::<$in_ty>() == std::any::TypeId::of::<$out_ty>() {
+        if ::core::any::TypeId::of::<$in_ty>() == ::core::any::TypeId::of::<$out_ty>() {
             // Store the value in an `Option` so we can `take`
             // it after casting to `&mut dyn Any`.
             let mut slot = Some($val);
             // Re-write the `$val` ident with the downcasted value.
-            let $val = (&mut slot as &mut dyn std::any::Any)
+            let $val = (&mut slot as &mut dyn ::core::any::Any)
                 .downcast_mut::<Option<$out_ty>>()
                 .unwrap()
                 .take()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
-use std::error;
-use std::fmt;
-use std::result;
+use core::error;
+use core::fmt;
 
 use crate::header;
+#[cfg(feature = "alloc")]
 use crate::header::MaxSizeReached;
 use crate::method;
 use crate::status;
+#[cfg(feature = "alloc")]
 use crate::uri;
 
 /// A generic "error" for HTTP connections
@@ -19,15 +20,19 @@ pub struct Error {
 }
 
 /// A `Result` typedef to use with the `http::Error` type
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 enum ErrorKind {
     StatusCode(status::InvalidStatusCode),
     Method(method::InvalidMethod),
+    #[cfg(feature = "alloc")]
     Uri(uri::InvalidUri),
+    #[cfg(feature = "alloc")]
     UriParts(uri::InvalidUriParts),
     HeaderName(header::InvalidHeaderName),
+    #[cfg(feature = "alloc")]
     HeaderValue(header::InvalidHeaderValue),
+    #[cfg(feature = "alloc")]
     MaxSizeReached(MaxSizeReached),
 }
 
@@ -59,10 +64,14 @@ impl Error {
         match self.inner {
             StatusCode(ref e) => e,
             Method(ref e) => e,
+            #[cfg(feature = "alloc")]
             Uri(ref e) => e,
+            #[cfg(feature = "alloc")]
             UriParts(ref e) => e,
             HeaderName(ref e) => e,
+            #[cfg(feature = "alloc")]
             HeaderValue(ref e) => e,
+            #[cfg(feature = "alloc")]
             MaxSizeReached(ref e) => e,
         }
     }
@@ -76,6 +85,7 @@ impl error::Error for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<MaxSizeReached> for Error {
     fn from(err: MaxSizeReached) -> Error {
         Error {
@@ -100,6 +110,7 @@ impl From<method::InvalidMethod> for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<uri::InvalidUri> for Error {
     fn from(err: uri::InvalidUri) -> Error {
         Error {
@@ -108,6 +119,7 @@ impl From<uri::InvalidUri> for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<uri::InvalidUriParts> for Error {
     fn from(err: uri::InvalidUriParts) -> Error {
         Error {
@@ -124,6 +136,7 @@ impl From<header::InvalidHeaderName> for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<header::InvalidHeaderValue> for Error {
     fn from(err: header::InvalidHeaderValue) -> Error {
         Error {
@@ -132,8 +145,8 @@ impl From<header::InvalidHeaderValue> for Error {
     }
 }
 
-impl From<std::convert::Infallible> for Error {
-    fn from(err: std::convert::Infallible) -> Error {
+impl From<core::convert::Infallible> for Error {
+    fn from(err: core::convert::Infallible) -> Error {
         match err {}
     }
 }
@@ -147,10 +160,12 @@ mod tests {
         if let Err(e) = status::StatusCode::from_u16(6666) {
             let err: Error = e.into();
             let ie = err.get_ref();
+            #[cfg(feature = "alloc")]
             assert!(!ie.is::<header::InvalidHeaderValue>());
             assert!(ie.is::<status::InvalidStatusCode>());
             ie.downcast_ref::<status::InvalidStatusCode>().unwrap();
 
+            #[cfg(feature = "alloc")]
             assert!(!err.is::<header::InvalidHeaderValue>());
             assert!(err.is::<status::InvalidStatusCode>());
         } else {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,9 +1,13 @@
-use std::any::{Any, TypeId};
-use std::collections::HashMap;
-use std::fmt;
-use std::hash::{BuildHasherDefault, Hasher};
+use alloc::boxed::Box;
+use core::any::{Any, TypeId};
+use core::fmt;
+use std::hash::Hasher;
 
-type AnyMap = HashMap<TypeId, Box<dyn AnyClone + Send + Sync>, BuildHasherDefault<IdHasher>>;
+type AnyMap = hashbrown::HashMap<
+    TypeId,
+    Box<dyn AnyClone + Send + Sync>,
+    core::hash::BuildHasherDefault<IdHasher>,
+>;
 
 // With TypeIds as keys, there's no need to hash them. They are already hashes
 // themselves, coming from the compiler. The IdHasher just holds the u64 of

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -70,16 +70,20 @@
 //! [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 //! [Robin Hood hashing]: https://en.wikipedia.org/wiki/Hash_table#Robin_Hood_hashing
 
+#[cfg(feature = "alloc")]
 mod map;
 mod name;
+#[cfg(feature = "alloc")]
 mod value;
 
+#[cfg(feature = "alloc")]
 pub use self::map::{
     AsHeaderName, Drain, Entry, GetAll, HeaderMap, IntoHeaderName, IntoIter, Iter, IterMut, Keys,
     MaxSizeReached, OccupiedEntry, VacantEntry, ValueDrain, ValueIter, ValueIterMut, Values,
     ValuesMut,
 };
 pub use self::name::{HeaderName, InvalidHeaderName};
+#[cfg(feature = "alloc")]
 pub use self::value::{HeaderValue, InvalidHeaderValue, ToStrError};
 
 // Use header name constants

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! server you might want to inspect a requests URI to dispatch it:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use http::{Request, Response};
 //!
 //! fn response(req: Request<()>) -> http::Result<Response<()>> {
@@ -40,6 +41,7 @@
 //! # fn foo(_req: Request<()>) -> http::Result<Response<()>> { panic!() }
 //! # fn bar(_req: Request<()>) -> http::Result<Response<()>> { panic!() }
 //! # fn not_found(_req: Request<()>) -> http::Result<Response<()>> { panic!() }
+//! # }
 //! ```
 //!
 //! On a [`Request`] you'll also find accessors like [`method`][Request::method] to return a
@@ -50,6 +52,7 @@
 //! to edit the request/response:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use http::{HeaderValue, Response, StatusCode};
 //! use http::header::CONTENT_TYPE;
 //!
@@ -58,6 +61,7 @@
 //!         .insert(CONTENT_TYPE, HeaderValue::from_static("text/html"));
 //!     *response.status_mut() = StatusCode::OK;
 //! }
+//! # }
 //! ```
 //!
 //! And finally, one of the most important aspects of requests/responses, the
@@ -113,19 +117,23 @@
 //! function:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use http::HeaderValue;
 //!
 //! let value = HeaderValue::from_static("text/html");
 //! assert_eq!(value.as_bytes(), b"text/html");
+//! # }
 //! ```
 //!
 //! And header values can also be parsed like names:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use http::HeaderValue;
 //!
 //! let value = "text/html";
 //! let value = value.parse::<HeaderValue>().unwrap();
+//! # }
 //! ```
 //!
 //! Most HTTP requests and responses tend to come with more than one header, so
@@ -142,6 +150,7 @@
 //! interpret it:
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use http::Uri;
 //! use http::uri::Scheme;
 //!
@@ -151,17 +160,21 @@
 //! assert_eq!(uri.host(), Some("www.rust-lang.org"));
 //! assert_eq!(uri.path(), "/index.html");
 //! assert_eq!(uri.query(), None);
+//! # }
 //! ```
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
-
-//#![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(not(feature = "std"))]
-compile_error!("`std` feature currently required, support for `no_std` may be added later");
+#![no_std]
 
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
+
+#[cfg(any(feature = "alloc", test))]
+extern crate alloc;
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
 
 #[cfg(test)]
 doctest!("../README.md");
@@ -171,27 +184,41 @@ mod convert;
 
 pub mod header;
 pub mod method;
+#[cfg(feature = "alloc")]
 pub mod request;
+#[cfg(feature = "alloc")]
 pub mod response;
 pub mod status;
+
+#[cfg(feature = "alloc")]
 pub mod uri;
 pub mod version;
 
+#[cfg(feature = "alloc")]
 mod byte_str;
 mod error;
+
+#[cfg(feature = "alloc")]
 mod extensions;
 
 pub use crate::error::{Error, Result};
+#[cfg(feature = "alloc")]
 pub use crate::extensions::Extensions;
+pub use crate::header::HeaderName;
 #[doc(no_inline)]
-pub use crate::header::{HeaderMap, HeaderName, HeaderValue};
+#[cfg(feature = "alloc")]
+pub use crate::header::{HeaderMap, HeaderValue};
 pub use crate::method::Method;
+#[cfg(feature = "alloc")]
 pub use crate::request::Request;
+#[cfg(feature = "alloc")]
 pub use crate::response::Response;
 pub use crate::status::StatusCode;
+#[cfg(feature = "alloc")]
 pub use crate::uri::Uri;
 pub use crate::version::Version;
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/request.rs
+++ b/src/request.rs
@@ -52,14 +52,14 @@
 //! }
 //! ```
 
-use std::any::Any;
-use std::convert::TryInto;
-use std::fmt;
+use core::any::Any;
+use core::convert::TryInto;
+use core::fmt;
 
 use crate::header::{HeaderMap, HeaderName, HeaderValue};
 use crate::method::Method;
 use crate::version::Version;
-use crate::{Extensions, Result, Uri};
+use crate::{Result, Uri};
 
 /// Represents an HTTP request.
 ///
@@ -179,7 +179,8 @@ pub struct Parts {
     pub headers: HeaderMap<HeaderValue>,
 
     /// The request's extensions
-    pub extensions: Extensions,
+    #[cfg(feature = "alloc")]
+    pub extensions: crate::Extensions,
 
     _priv: (),
 }
@@ -581,8 +582,9 @@ impl<T> Request<T> {
     /// let request: Request<()> = Request::default();
     /// assert!(request.extensions().get::<i32>().is_none());
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
-    pub fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &crate::Extensions {
         &self.head.extensions
     }
 
@@ -597,8 +599,9 @@ impl<T> Request<T> {
     /// request.extensions_mut().insert("hello");
     /// assert_eq!(request.extensions().get(), Some(&"hello"));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
+    pub fn extensions_mut(&mut self) -> &mut crate::Extensions {
         &mut self.head.extensions
     }
 
@@ -714,7 +717,7 @@ impl Parts {
             uri: Uri::default(),
             version: Version::default(),
             headers: HeaderMap::default(),
-            extensions: Extensions::default(),
+            extensions: crate::Extensions::default(),
             _priv: (),
         }
     }
@@ -991,7 +994,7 @@ impl Builder {
     /// assert_eq!(extensions.get::<&'static str>(), Some(&"My Extension"));
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
-    pub fn extensions_ref(&self) -> Option<&Extensions> {
+    pub fn extensions_ref(&self) -> Option<&crate::Extensions> {
         self.inner.as_ref().ok().map(|h| &h.extensions)
     }
 
@@ -1009,7 +1012,7 @@ impl Builder {
     /// extensions.insert(5u32);
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
-    pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
+    pub fn extensions_mut(&mut self) -> Option<&mut crate::Extensions> {
         self.inner.as_mut().ok().map(|h| &mut h.extensions)
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -61,14 +61,14 @@
 //! // ...
 //! ```
 
-use std::any::Any;
-use std::convert::TryInto;
-use std::fmt;
+use core::any::Any;
+use core::convert::TryInto;
+use core::fmt;
 
 use crate::header::{HeaderMap, HeaderName, HeaderValue};
 use crate::status::StatusCode;
 use crate::version::Version;
-use crate::{Extensions, Result};
+use crate::Result;
 
 /// Represents an HTTP response
 ///
@@ -197,8 +197,9 @@ pub struct Parts {
     /// The response's headers
     pub headers: HeaderMap<HeaderValue>,
 
+    #[cfg(feature = "alloc")]
     /// The response's extensions
-    pub extensions: Extensions,
+    pub extensions: crate::Extensions,
 
     _priv: (),
 }
@@ -374,8 +375,9 @@ impl<T> Response<T> {
     /// let response: Response<()> = Response::default();
     /// assert!(response.extensions().get::<i32>().is_none());
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
-    pub fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &crate::Extensions {
         &self.head.extensions
     }
 
@@ -390,8 +392,9 @@ impl<T> Response<T> {
     /// response.extensions_mut().insert("hello");
     /// assert_eq!(response.extensions().get(), Some(&"hello"));
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
+    pub fn extensions_mut(&mut self) -> &mut crate::Extensions {
         &mut self.head.extensions
     }
 
@@ -506,7 +509,8 @@ impl Parts {
             status: StatusCode::default(),
             version: Version::default(),
             headers: HeaderMap::default(),
-            extensions: Extensions::default(),
+            #[cfg(feature = "alloc")]
+            extensions: crate::Extensions::default(),
             _priv: (),
         }
     }
@@ -681,6 +685,7 @@ impl Builder {
     /// assert_eq!(response.extensions().get::<&'static str>(),
     ///            Some(&"My Extension"));
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn extension<T>(self, extension: T) -> Builder
     where
         T: Clone + Any + Send + Sync + 'static,
@@ -704,7 +709,8 @@ impl Builder {
     /// assert_eq!(extensions.get::<&'static str>(), Some(&"My Extension"));
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
-    pub fn extensions_ref(&self) -> Option<&Extensions> {
+    #[cfg(feature = "alloc")]
+    pub fn extensions_ref(&self) -> Option<&crate::Extensions> {
         self.inner.as_ref().ok().map(|h| &h.extensions)
     }
 
@@ -722,7 +728,8 @@ impl Builder {
     /// extensions.insert(5u32);
     /// assert_eq!(extensions.get::<u32>(), Some(&5u32));
     /// ```
-    pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
+    #[cfg(feature = "alloc")]
+    pub fn extensions_mut(&mut self) -> Option<&mut crate::Extensions> {
         self.inner.as_mut().ok().map(|h| &mut h.extensions)
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -14,11 +14,11 @@
 //! assert!(StatusCode::OK.is_success());
 //! ```
 
-use std::convert::TryFrom;
-use std::error::Error;
-use std::fmt;
-use std::num::NonZeroU16;
-use std::str::FromStr;
+use core::convert::TryFrom;
+use core::error::Error;
+use core::fmt;
+use core::num::NonZeroU16;
+use core::str::FromStr;
 
 /// An HTTP status code (`status-code` in RFC 9110 et al.).
 ///
@@ -267,7 +267,7 @@ impl FromStr for StatusCode {
 impl<'a> From<&'a StatusCode> for StatusCode {
     #[inline]
     fn from(t: &'a StatusCode) -> Self {
-        t.to_owned()
+        *t
     }
 }
 

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -1,7 +1,7 @@
-use std::convert::TryFrom;
-use std::hash::{Hash, Hasher};
-use std::str::FromStr;
-use std::{cmp, fmt, str};
+use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
+use core::str::FromStr;
+use core::{cmp, fmt, str};
 
 use bytes::Bytes;
 
@@ -21,6 +21,7 @@ impl Authority {
         }
     }
 
+    #[cfg(feature = "alloc")]
     // Not public while `bytes` is unstable.
     pub(super) fn from_shared(s: Bytes) -> Result<Self, InvalidUri> {
         // Precondition on create_authority: trivially satisfied by the
@@ -314,13 +315,15 @@ impl<'a> PartialEq<&'a str> for Authority {
     }
 }
 
-impl PartialEq<String> for Authority {
-    fn eq(&self, other: &String) -> bool {
+#[cfg(feature = "alloc")]
+impl PartialEq<alloc::string::String> for Authority {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         self.data.eq_ignore_ascii_case(other.as_str())
     }
 }
 
-impl PartialEq<Authority> for String {
+#[cfg(feature = "alloc")]
+impl PartialEq<Authority> for alloc::string::String {
     fn eq(&self, other: &Authority) -> bool {
         self.as_str().eq_ignore_ascii_case(other.as_str())
     }
@@ -376,15 +379,17 @@ impl<'a> PartialOrd<&'a str> for Authority {
     }
 }
 
-impl PartialOrd<String> for Authority {
-    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+#[cfg(feature = "alloc")]
+impl PartialOrd<alloc::string::String> for Authority {
+    fn partial_cmp(&self, other: &alloc::string::String) -> Option<cmp::Ordering> {
         let left = self.data.as_bytes().iter().map(|b| b.to_ascii_lowercase());
         let right = other.as_bytes().iter().map(|b| b.to_ascii_lowercase());
         left.partial_cmp(right)
     }
 }
 
-impl PartialOrd<Authority> for String {
+#[cfg(feature = "alloc")]
+impl PartialOrd<Authority> for alloc::string::String {
     fn partial_cmp(&self, other: &Authority) -> Option<cmp::Ordering> {
         let left = self.as_bytes().iter().map(|b| b.to_ascii_lowercase());
         let right = other.data.as_bytes().iter().map(|b| b.to_ascii_lowercase());
@@ -446,20 +451,22 @@ impl<'a> TryFrom<&'a str> for Authority {
     }
 }
 
-impl TryFrom<Vec<u8>> for Authority {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::vec::Vec<u8>> for Authority {
     type Error = InvalidUri;
 
     #[inline]
-    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(vec: alloc::vec::Vec<u8>) -> Result<Self, Self::Error> {
         Authority::from_shared(vec.into())
     }
 }
 
-impl TryFrom<String> for Authority {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::string::String> for Authority {
     type Error = InvalidUri;
 
     #[inline]
-    fn try_from(t: String) -> Result<Self, Self::Error> {
+    fn try_from(t: alloc::string::String) -> Result<Self, Self::Error> {
         Authority::from_shared(t.into())
     }
 }
@@ -531,6 +538,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn parse_empty_string_is_error() {

--- a/src/uri/builder.rs
+++ b/src/uri/builder.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use super::{Authority, Parts, PathAndQuery, Scheme};
 use crate::Uri;
@@ -163,6 +163,7 @@ impl From<Uri> for Builder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
 
     #[test]
     fn build_from_str() {

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -22,15 +22,17 @@
 //! assert_eq!(uri.path(), "/install.html");
 //! ```
 
-use crate::byte_str::ByteStr;
-use std::convert::TryFrom;
+use alloc::boxed::Box;
+use core::convert::TryFrom;
+use core::error::Error;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::str::FromStr;
+use core::str::{self};
 
 use bytes::Bytes;
 
-use std::error::Error;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::str::{self, FromStr};
+use crate::byte_str::ByteStr;
 
 use self::scheme::Scheme2;
 
@@ -723,29 +725,32 @@ impl<'a> TryFrom<&'a str> for Uri {
     }
 }
 
-impl<'a> TryFrom<&'a String> for Uri {
+#[cfg(feature = "alloc")]
+impl<'a> TryFrom<&'a alloc::string::String> for Uri {
     type Error = InvalidUri;
 
     #[inline]
-    fn try_from(t: &'a String) -> Result<Self, Self::Error> {
+    fn try_from(t: &'a alloc::string::String) -> Result<Self, Self::Error> {
         t.parse()
     }
 }
 
-impl TryFrom<String> for Uri {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::string::String> for Uri {
     type Error = InvalidUri;
 
     #[inline]
-    fn try_from(t: String) -> Result<Self, Self::Error> {
+    fn try_from(t: alloc::string::String) -> Result<Self, Self::Error> {
         Uri::from_shared(Bytes::from(t))
     }
 }
 
-impl TryFrom<Vec<u8>> for Uri {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::vec::Vec<u8>> for Uri {
     type Error = InvalidUri;
 
     #[inline]
-    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(vec: alloc::vec::Vec<u8>) -> Result<Self, Self::Error> {
         Uri::from_shared(Bytes::from(vec))
     }
 }

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -1,6 +1,7 @@
-use std::convert::TryFrom;
-use std::str::FromStr;
-use std::{cmp, fmt, hash, str};
+use core::convert::TryFrom;
+use core::hash::Hash;
+use core::str::FromStr;
+use core::{cmp, fmt, hash, str};
 
 use bytes::Bytes;
 
@@ -294,26 +295,29 @@ impl<'a> TryFrom<&'a str> for PathAndQuery {
     }
 }
 
-impl TryFrom<Vec<u8>> for PathAndQuery {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::vec::Vec<u8>> for PathAndQuery {
     type Error = InvalidUri;
     #[inline]
-    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(vec: alloc::vec::Vec<u8>) -> Result<Self, Self::Error> {
         PathAndQuery::from_shared(vec.into())
     }
 }
 
-impl TryFrom<String> for PathAndQuery {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::string::String> for PathAndQuery {
     type Error = InvalidUri;
     #[inline]
-    fn try_from(s: String) -> Result<Self, Self::Error> {
+    fn try_from(s: alloc::string::String) -> Result<Self, Self::Error> {
         PathAndQuery::from_shared(s.into())
     }
 }
 
-impl TryFrom<&String> for PathAndQuery {
+#[cfg(feature = "alloc")]
+impl TryFrom<&alloc::string::String> for PathAndQuery {
     type Error = InvalidUri;
     #[inline]
-    fn try_from(s: &String) -> Result<Self, Self::Error> {
+    fn try_from(s: &alloc::string::String) -> Result<Self, Self::Error> {
         TryFrom::try_from(s.as_bytes())
     }
 }
@@ -345,7 +349,7 @@ impl fmt::Display for PathAndQuery {
     }
 }
 
-impl hash::Hash for PathAndQuery {
+impl Hash for PathAndQuery {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.data.hash(state);
     }
@@ -390,14 +394,16 @@ impl PartialEq<PathAndQuery> for str {
     }
 }
 
-impl PartialEq<String> for PathAndQuery {
+#[cfg(feature = "alloc")]
+impl PartialEq<alloc::string::String> for PathAndQuery {
     #[inline]
-    fn eq(&self, other: &String) -> bool {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
-impl PartialEq<PathAndQuery> for String {
+#[cfg(feature = "alloc")]
+impl PartialEq<PathAndQuery> for alloc::string::String {
     #[inline]
     fn eq(&self, other: &PathAndQuery) -> bool {
         self.as_str() == other.as_str()
@@ -439,14 +445,16 @@ impl<'a> PartialOrd<PathAndQuery> for &'a str {
     }
 }
 
-impl PartialOrd<String> for PathAndQuery {
+#[cfg(feature = "alloc")]
+impl PartialOrd<alloc::string::String> for PathAndQuery {
     #[inline]
-    fn partial_cmp(&self, other: &String) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &alloc::string::String) -> Option<cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
     }
 }
 
-impl PartialOrd<PathAndQuery> for String {
+#[cfg(feature = "alloc")]
+impl PartialOrd<PathAndQuery> for alloc::string::String {
     #[inline]
     fn partial_cmp(&self, other: &PathAndQuery) -> Option<cmp::Ordering> {
         self.as_str().partial_cmp(other.as_str())
@@ -456,6 +464,8 @@ impl PartialOrd<PathAndQuery> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
+    use alloc::string::ToString;
 
     #[test]
     fn equal_to_self_of_same_path() {

--- a/src/uri/port.rs
+++ b/src/uri/port.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use super::{ErrorKind, InvalidUri};
 
@@ -128,7 +128,7 @@ mod tests {
             port: 8081,
         };
         let port_b = Port {
-            repr: String::from("8081"),
+            repr: alloc::string::String::from("8081"),
             port: 8081,
         };
         assert_eq!(port_a, port_b);

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -1,4 +1,6 @@
-use std::str::FromStr;
+use alloc::string::ToString;
+use alloc::vec;
+use core::str::FromStr;
 
 use super::{ErrorKind, InvalidUri, Port, Uri, URI_CHARS};
 
@@ -442,11 +444,11 @@ fn test_uri_parse_error() {
 
 #[test]
 fn test_max_uri_len() {
-    let mut uri = vec![];
+    let mut uri = alloc::vec![];
     uri.extend(b"http://localhost/");
-    uri.extend(vec![b'a'; 70 * 1024]);
+    uri.extend([b'a'; 70 * 1024]);
 
-    let uri = String::from_utf8(uri).unwrap();
+    let uri = core::str::from_utf8(&uri).unwrap();
     let res: Result<Uri, InvalidUri> = uri.parse();
 
     assert_eq!(res.unwrap_err().0, ErrorKind::TooLong);
@@ -454,11 +456,11 @@ fn test_max_uri_len() {
 
 #[test]
 fn test_overflowing_scheme() {
-    let mut uri = vec![];
-    uri.extend(vec![b'a'; 256]);
+    let mut uri = alloc::vec![];
+    uri.extend([b'a'; 256]);
     uri.extend(b"://localhost/");
 
-    let uri = String::from_utf8(uri).unwrap();
+    let uri = core::str::from_utf8(&uri).unwrap();
     let res: Result<Uri, InvalidUri> = uri.parse();
 
     assert_eq!(res.unwrap_err().0, ErrorKind::SchemeTooLong);
@@ -466,11 +468,11 @@ fn test_overflowing_scheme() {
 
 #[test]
 fn test_max_length_scheme() {
-    let mut uri = vec![];
-    uri.extend(vec![b'a'; 64]);
+    let mut uri = alloc::vec![];
+    uri.extend([b'a'; 64]);
     uri.extend(b"://localhost/");
 
-    let uri = String::from_utf8(uri).unwrap();
+    let uri = core::str::from_utf8(&uri).unwrap();
     let uri: Uri = uri.parse().unwrap();
 
     assert_eq!(uri.scheme_str().unwrap().len(), 64);

--- a/src/version.rs
+++ b/src/version.rs
@@ -19,7 +19,7 @@
 //! println!("{:?}", http2);
 //! ```
 
-use std::fmt;
+use core::fmt;
 
 /// Represents a version of the HTTP spec.
 #[derive(PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]


### PR DESCRIPTION
Makes the crate unconditionally `#![no_std]` and pulls in `extern crate alloc` and `extern crate std` as configured by feature flags (`std` remains the default).

All functionality other than `HeaderMap::try_from::<std::collections::HashMap>` can be implemented with `alloc` + `hashbrown`, so this crate should be usable on embedded platforms functionally as-is.

Without `alloc`, we can only provide support for methods, status codes, versions, and standard header names, a pretty limited subset of functionality, though still useful for consistent types in contexts without allocation. I'd be very interested in working on a future PR adding `heapless` support (if the maintainers are amenable) so that most of this crate can work without an allocator, but that won't make it into this PR.

Worth noting that #732 exists -- not aiming to tread on toes, I just wasn't aware of it until I went to submit this.

All tests pass with all combinations of feature flags.

## Compatibility / substantive changes
Almost all the changes in this PR are mechanical renamings of `std` imports to `core` or `alloc`. The next most common changes are adding `#[cfg(feature = "alloc")]` where appropriate.

There are no functional or compatibility changes with the `std` feature flag, and dropping to `alloc` from `std` only removes the `HeaderMap::try_from<std::collections::HashMap>` impl (while one is still provided for `hashbrown::HashMap` and `alloc::collections::BTreeMap`).

Some code changes were necessary to support non-`alloc` environments -- these are in `header/name.rs`, `method.rs`, and `uri/scheme.rs`:

- Custom header names are not parseable
- Non-inlineable extension methods are invalid
- Non-HTTP(s) schemes can't be parsed or constructed