### PR TITLE
Added support for title case header name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,13 @@ edition = "2018"
 rust-version = "1.49.0"
 
 [workspace]
-members = [
-  ".",
-]
-exclude = [
-  "fuzz",
-  "benches"
-]
+members = ["."]
+exclude = ["fuzz", "benches"]
 
 [features]
 default = ["std"]
 std = []
+title-case-header-name = []
 
 [dependencies]
 bytes = "1"
@@ -43,7 +39,7 @@ itoa = "1"
 
 [dev-dependencies]
 quickcheck = "1"
-rand = "0.8.0"
+rand = "0.9.0"
 serde = "1.0"
 serde_json = "1.0"
 doc-comment = "0.3"


### PR DESCRIPTION
I encountered an [issue](https://discuss.ai.google.dev/t/bug-request-header-is-not-properly-handled-for-v1beta-openai-chat-completions/65731) with the OpenAI compatibility API endpoint while using `reqwest`. It turns out the endpoint requires the `host` header to be in title case (`Host`). 

This PR adding a new feature flag to allow developer to use title case header name.