### PR TITLE
feat: add fmt::Display for Version to improve usage

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -73,3 +73,17 @@ impl fmt::Debug for Version {
         })
     }
 }
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let version_str = match self.0 {
+            Http::Http09 => "HTTP/0.9",
+            Http::Http10 => "HTTP/1.0",
+            Http::Http11 => "HTTP/1.1",
+            Http::H2 => "HTTP/2.0",
+            Http::H3 => "HTTP/3.0",
+            Http::__NonExhaustive => unreachable!(),
+        };
+        write!(f, "{}", version_str)
+    }
+}


### PR DESCRIPTION
Hey maintainer, 

I've implemented the `Display` trait for the `Version` enum to align its use with other components such as Uri and Method. 

This enhancement simplifies code when working with libraries such as Axum, which exploits the http crate. Previously, converting a Version into a string (for inclusion in OpenTelemetry span in my case) required the use of the `format!` macro! 

With this implementation, we can now call .to_string() directly on Version instances, simplifying the code base and improving readability.