### PR TITLE
Block leading and trailing whitespace in field values

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -241,7 +241,14 @@ impl HeaderValue {
         src: T,
         into: F,
     ) -> Result<HeaderValue, InvalidHeaderValue> {
-        for &b in src.as_ref() {
+        let u8_slice = src.as_ref();
+        match u8_slice {
+            [b' ', ..] | [b'\t', ..] | [.., b' '] | [.., b'\t'] => {
+                return Err(InvalidHeaderValue { _priv: () })
+            }
+            _ => (),
+        };
+        for &b in u8_slice {
             if !is_valid(b) {
                 return Err(InvalidHeaderValue { _priv: () });
             }


### PR DESCRIPTION
This blocks header values with leading and trailing whitespace. This is not needed for HTTP/1.x where the parser already strips such whitespace, but in HTTP/2 and HTTP/3 the parser does not strip such whitespace and so it is up to the `http` crate to reject such headers.

Different HTTP/2 and HTTP/3 libraries treat such values differently, so rejection is the safest option.

Fixes #245