### PR TITLE
Make `StatusCode::from_u16` const

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -70,14 +70,13 @@ impl StatusCode {
     /// assert!(err.is_err());
     /// ```
     #[inline]
-    pub fn from_u16(src: u16) -> Result<StatusCode, InvalidStatusCode> {
-        if !(100..1000).contains(&src) {
-            return Err(InvalidStatusCode::new());
+    pub const fn from_u16(src: u16) -> Result<StatusCode, InvalidStatusCode> {
+        if let 100..=999 = src {
+            if let Some(code) = NonZeroU16::new(src) {
+                return Ok(StatusCode(code));
+            }
         }
-
-        NonZeroU16::new(src)
-            .map(StatusCode)
-            .ok_or_else(InvalidStatusCode::new)
+        Err(InvalidStatusCode::new())
     }
 
     /// Converts a `&[u8]` to a status code.
@@ -523,7 +522,7 @@ status_codes! {
 }
 
 impl InvalidStatusCode {
-    fn new() -> InvalidStatusCode {
+    const fn new() -> InvalidStatusCode {
         InvalidStatusCode { _priv: () }
     }
 }


### PR DESCRIPTION
Don't even need to feature-gate it or anything, this works on 1.49.