### PR TITLE
Add some tests for HeaderMap, Authority, PathAndQuery, and Uri

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -326,4 +326,15 @@ fn test_extensions() {
 
     assert_eq!(extensions.get::<bool>(), None);
     assert_eq!(extensions.get(), Some(&MyType(10)));
+
+    let mut ext_a = Extensions::new();
+
+    let mut ext_b = Extensions::new();
+    ext_b.insert(4u8);
+    ext_b.insert("hello");
+
+    ext_a.extend(ext_b);
+    assert_eq!(ext_a.len(), 2);
+    assert_eq!(ext_a.get::<u8>(), Some(&4u8));
+    assert_eq!(ext_a.get::<&'static str>().copied(), Some("hello"));
 }

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -3902,3 +3902,10 @@ fn skip_duplicates_during_key_iteration() {
     map.try_append("a", HeaderValue::from_static("b")).unwrap();
     assert_eq!(map.keys().count(), map.keys_len());
 }
+
+#[test]
+fn test_headermap_get_mut() {
+    let mut map: HeaderMap<String> = HeaderMap::default();
+    let result = map.get_mut("invalid_key");
+    assert!(result.is_none());
+}

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1918,5 +1918,13 @@ mod tests {
         HeaderName::from_lowercase(&[b'A'; 100]).unwrap_err();
         HeaderName::from_lowercase(&[0x1; 100]).unwrap_err();
         HeaderName::from_lowercase(&[0xFF; 100]).unwrap_err();
+        HeaderName::from_lowercase(&[b'a'; SCRATCH_BUF_OVERFLOW]).unwrap();
+    }
+
+    #[test]
+    fn test_eq_ignore_ascii_case() {
+        let lower: &[u8] = b"a";
+        let s: &[u8] = b"";
+        assert_eq!(eq_ignore_ascii_case(lower, s), false);
     }
 }

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -796,3 +796,14 @@ fn test_debug() {
     sensitive.set_sensitive(true);
     assert_eq!("Sensitive", format!("{:?}", sensitive));
 }
+
+#[test]
+fn from_maybe_shared() {
+    let bytes = Bytes::from_static(b"test");
+    let result = HeaderValue::from_maybe_shared(bytes);
+    assert!(result.is_ok());
+
+    let slice: &[u8] = b"example";
+    let result = HeaderValue::from_maybe_shared(slice);
+    assert!(result.is_ok());
+}

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -681,4 +681,13 @@ mod tests {
         let err = Authority::parse_non_empty(b"]o[").unwrap_err();
         assert_eq!(err.0, ErrorKind::InvalidAuthority);
     }
+
+    #[test]
+    fn from_maybe_shared() {
+        let result = Authority::from_maybe_shared(Bytes::new());
+        assert!(result.is_err());
+
+        let result = Authority::from_maybe_shared("example.com");
+        assert!(result.is_ok());
+    }
 }

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -497,6 +497,17 @@ mod tests {
     }
 
     #[test]
+    fn from_maybe_shared() {
+        let input = Bytes::from_static(b"example?query=string");
+        let result = PathAndQuery::from_maybe_shared(input);
+        assert!(result.is_ok());
+
+        let input: &[u8] = b"";
+        let result = PathAndQuery::from_maybe_shared(input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn not_equal_with_a_str_of_a_different_path() {
         let path_and_query: PathAndQuery = "/hello/world&foo=bar".parse().unwrap();
         // as a reference

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -517,3 +517,23 @@ fn test_partial_eq_path_with_terminating_questionmark() {
 
     assert_eq!(uri, a);
 }
+
+#[test]
+#[should_panic = "static str is not valid URI"]
+fn test_uri_from_static() {
+    let s = "";
+    let _result = Uri::from_static(s);
+}
+
+#[test]
+fn test_url_from_maybe_shared() {
+    use bytes::Bytes;
+
+    let input = Bytes::from_static(b"http://example.com");
+    let result = Uri::from_maybe_shared(input);
+    assert!(result.is_ok());
+
+    let input: &[u8] = b"mailto:user@example.com";
+    let result = Uri::from_maybe_shared(input).unwrap();
+    assert_eq!(result.query(), None);
+}


### PR DESCRIPTION
Hi team,

This pull request adds a suite of new tests aimed at improving the test coverage within the repository.

The primary focus of these tests is on the HeaderMap, Authority, PathAndQuery, and Uri. We've ensured these tests are robust and cover key scenarios.

We appreciate your time in reviewing these additions.

Thanks.