### PR TITLE
Add `as_str` to `Version` type

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -42,6 +42,20 @@ impl Version {
     pub const HTTP_3: Version = Version(Http::H3);
 }
 
+impl Version {
+    /// Returns a `&'static str` representation of the HTTP version.
+    pub fn as_str(&self) -> &'static str {
+        match self.0 {
+            Http::Http09 => "HTTP/0.9",
+            Http::Http10 => "HTTP/1.0",
+            Http::Http11 => "HTTP/1.1",
+            Http::H2 => "HTTP/2.0",
+            Http::H3 => "HTTP/3.0",
+            Http::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
 #[derive(PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
 enum Http {
     Http09,
@@ -61,15 +75,6 @@ impl Default for Version {
 
 impl fmt::Debug for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::Http::*;
-
-        f.write_str(match self.0 {
-            Http09 => "HTTP/0.9",
-            Http10 => "HTTP/1.0",
-            Http11 => "HTTP/1.1",
-            H2 => "HTTP/2.0",
-            H3 => "HTTP/3.0",
-            __NonExhaustive => unreachable!(),
-        })
+        f.write_str(self.as_str())
     }
 }


### PR DESCRIPTION
Stringifications of the variants of the `Version` are known at compile time so requiring a `Debug` format is not necessary.

This is nice for me specifically because I want to record the HTTP version of queries using `metrics` crate. This crate allows users to record labels as either a `String` or `&'static str`, and given I didn't want to allocate a `String` with the `Debug` format I had to copy-paste the lookup.