### PR TITLE
Use #[non_exhaustive]

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -43,13 +43,13 @@ impl Version {
 }
 
 #[derive(PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+#[non_exhaustive]
 enum Http {
     Http09,
     Http10,
     Http11,
     H2,
     H3,
-    __NonExhaustive,
 }
 
 impl Default for Version {
@@ -69,7 +69,6 @@ impl fmt::Debug for Version {
             Http11 => "HTTP/1.1",
             H2 => "HTTP/2.0",
             H3 => "HTTP/3.0",
-            __NonExhaustive => unreachable!(),
         })
     }
 }


### PR DESCRIPTION
It is stable since Rust 1.40

https://blog.rust-lang.org/2019/12/19/Rust-1.40.0/

and MSRV is 1.49

https://github.com/hyperium/http/blob/4304e604fc668baf675867d9045145f015f0957e/Cargo.toml#L24