### PR TITLE
Add HTTP 103 Early Hints status code

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -333,6 +333,9 @@ status_codes! {
     /// 102 Processing
     /// [[RFC2518, Section 10.1](https://datatracker.ietf.org/doc/html/rfc2518#section-10.1)]
     (102, PROCESSING, "Processing");
+    /// 103 Early Hints
+    /// [[RFC8297, Section 2](https://datatracker.ietf.org/doc/html/rfc8297#section-2)]
+    (103, EARLY_HINTS, "Early Hints");
 
     /// 200 OK
     /// [[RFC9110, Section 15.3.1](https://datatracker.ietf.org/doc/html/rfc9110#section-15.3.1)]


### PR DESCRIPTION
feat(status): add HTTP 103 early hints status code

Add support for HTTP 103 Early Hints status code as defined in RFC 8297.
This allows servers to send preliminary response headers before the final
response, improving performance for resource loading optimization.

The status code is added to the existing status_codes! macro with proper
documentation referencing RFC 8297 Section 2.