### PR TITLE
refactor(header): use better panic message in const HeaderName and HeaderValue

### DIFF
--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1205,27 +1205,6 @@ impl HeaderName {
     ///
     /// This function panics when the static string is a invalid header.
     ///
-    /// Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345)
-    /// makes its way into stable, the panic message at compile-time is
-    /// going to look cryptic, but should at least point at your header value:
-    ///
-    /// ```text
-    /// error: any use of this value will cause an error
-    ///     --> http/src/header/name.rs:1241:13
-    ///      |
-    /// 1241 |             ([] as [u8; 0])[0]; // Invalid header name
-    ///      |             ^^^^^^^^^^^^^^^^^^
-    ///      |             |
-    ///      |             index out of bounds: the length is 0 but the index is 0
-    ///      |             inside `http::HeaderName::from_static` at http/src/header/name.rs:1241:13
-    ///      |             inside `INVALID_NAME` at src/main.rs:3:34
-    ///      |
-    ///     ::: src/main.rs:3:1
-    ///      |
-    /// 3    | const INVALID_NAME: HeaderName = HeaderName::from_static("Capitalized");
-    ///      | ------------------------------------------------------------------------
-    /// ```
-    ///
     /// # Examples
     ///
     /// ```
@@ -1252,7 +1231,6 @@ impl HeaderName {
     /// let a = HeaderName::from_static("foobar");
     /// let b = HeaderName::from_static("FOOBAR"); // This line panics!
     /// ```
-    #[allow(unconditional_panic)] // required for the panic circumvention
     pub const fn from_static(src: &'static str) -> HeaderName {
         let name_bytes = src.as_bytes();
         if let Some(standard) = StandardHeader::from_bytes(name_bytes) {
@@ -1272,13 +1250,8 @@ impl HeaderName {
                 i += 1;
             }
         } {
-            // TODO: When msrv is bumped to larger than 1.57, this should be
-            // replaced with `panic!` macro.
-            // https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts
-            //
-            // See the panics section of this method's document for details.
-            #[allow(clippy::no_effect, clippy::out_of_bounds_indexing)]
-            ([] as [u8; 0])[0]; // Invalid header name
+            // Invalid header name
+            panic!("HeaderName::from_static with invalid bytes")
         }
 
         HeaderName {

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -51,27 +51,6 @@ impl HeaderValue {
     /// This function panics if the argument contains invalid header value
     /// characters.
     ///
-    /// Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345)
-    /// makes its way into stable, the panic message at compile-time is
-    /// going to look cryptic, but should at least point at your header value:
-    ///
-    /// ```text
-    /// error: any use of this value will cause an error
-    ///   --> http/src/header/value.rs:67:17
-    ///    |
-    /// 67 |                 ([] as [u8; 0])[0]; // Invalid header value
-    ///    |                 ^^^^^^^^^^^^^^^^^^
-    ///    |                 |
-    ///    |                 index out of bounds: the length is 0 but the index is 0
-    ///    |                 inside `HeaderValue::from_static` at http/src/header/value.rs:67:17
-    ///    |                 inside `INVALID_HEADER` at src/main.rs:73:33
-    ///    |
-    ///   ::: src/main.rs:73:1
-    ///    |
-    /// 73 | const INVALID_HEADER: HeaderValue = HeaderValue::from_static("жsome value");
-    ///    | ----------------------------------------------------------------------------
-    /// ```
-    ///
     /// # Examples
     ///
     /// ```
@@ -80,19 +59,12 @@ impl HeaderValue {
     /// assert_eq!(val, "hello");
     /// ```
     #[inline]
-    #[allow(unconditional_panic)] // required for the panic circumvention
     pub const fn from_static(src: &'static str) -> HeaderValue {
         let bytes = src.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
             if !is_visible_ascii(bytes[i]) {
-                // TODO: When msrv is bumped to larger than 1.57, this should be
-                // replaced with `panic!` macro.
-                // https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts
-                //
-                // See the panics section of this method's document for details.
-                #[allow(clippy::no_effect, clippy::out_of_bounds_indexing)]
-                ([] as [u8; 0])[0]; // Invalid header value
+                panic!("HeaderValue::from_static with invalid bytes")
             }
             i += 1;
         }


### PR DESCRIPTION
Now that MSRV is 1.57, we can use better panic messages in the const fns.