### PR TITLE
docs: remove unnecessary extern crate sentence

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -118,9 +118,6 @@ use crate::{Extensions, Result, Uri};
 /// Deserialize a request of bytes via json:
 ///
 /// ```
-/// # extern crate serde;
-/// # extern crate serde_json;
-/// # extern crate http;
 /// use http::Request;
 /// use serde::de;
 ///
@@ -138,9 +135,6 @@ use crate::{Extensions, Result, Uri};
 /// Or alternatively, serialize the body of a request to json
 ///
 /// ```
-/// # extern crate serde;
-/// # extern crate serde_json;
-/// # extern crate http;
 /// use http::Request;
 /// use serde::ser;
 ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -140,9 +140,6 @@ use crate::{Extensions, Result};
 /// Deserialize a response of bytes via json:
 ///
 /// ```
-/// # extern crate serde;
-/// # extern crate serde_json;
-/// # extern crate http;
 /// use http::Response;
 /// use serde::de;
 ///
@@ -160,9 +157,6 @@ use crate::{Extensions, Result};
 /// Or alternatively, serialize the body of a response to json
 ///
 /// ```
-/// # extern crate serde;
-/// # extern crate serde_json;
-/// # extern crate http;
 /// use http::Response;
 /// use serde::ser;
 ///


### PR DESCRIPTION
Removes the unnecessary extern crate sentences.