### PR TITLE
chore(header): fix clippy::assign_op_pattern

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -3693,7 +3693,7 @@ impl std::hash::Hasher for FnvHasher {
     fn write(&mut self, bytes: &[u8]) {
         let mut hash = self.0;
         for &b in bytes {
-            hash = hash ^ (b as u64);
+            hash ^= b as u64;
             hash = hash.wrapping_mul(0x100000001b3);
         }
         self.0 = hash;


### PR DESCRIPTION
This fixes a clippy failure in `src/header/map.rs` that was introduced in 50b009c #796 .