### PR TITLE
Make `HeaderValue::set_sensitive` available in const contexts

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -298,6 +298,11 @@ impl HeaderValue {
 
     /// Mark that the header value represents sensitive information.
     ///
+    /// This method is `const` to allow marking constants created with
+    /// [`HeaderValue::from_static`] as sensitive. Note that sensitive values
+    /// that are embedded into an application are trivial to dump and cannot be
+    /// considered secure.
+    ///
     /// # Examples
     ///
     /// ```
@@ -311,7 +316,7 @@ impl HeaderValue {
     /// assert!(!val.is_sensitive());
     /// ```
     #[inline]
-    pub fn set_sensitive(&mut self, val: bool) {
+    pub const fn set_sensitive(&mut self, val: bool) {
         self.is_sensitive = val;
     }
 


### PR DESCRIPTION
Make `HeaderValue::set_sensitive` `const` to allow applications to embed sensitive header values statically.

Considering embedded client secrets are generally a red flag, add a comment to the method's documentation to urge developers not to consider embedded sensitive values secure. `const` use of `set_sensitive` should be limited to use cases where the developer is aware that the embedded secret will be world-readable.

This PR implements hyperium/http#807