### PR TITLE
fix: clamp Extend size hint so HeaderMap reserve cannot overflow

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -2133,11 +2133,15 @@ impl<T> Extend<(Option<HeaderName>, T)> for HeaderMap<T> {
         // Reserve the entire hint lower bound if the map is empty.
         // Otherwise reserve half the hint (rounded up), so the map
         // will only resize twice in the worst case.
-        let reserve = if self.is_empty() {
+        let hint = if self.is_empty() {
             iter.size_hint().0
         } else {
             (iter.size_hint().0 + 1) / 2
         };
+
+        // Clamp the hint so an over-estimate cannot overflow `reserve`.
+        let max_reserve = usable_capacity(MAX_SIZE).saturating_sub(self.entries.len());
+        let reserve = hint.min(max_reserve);
 
         self.reserve(reserve);
 
@@ -2189,11 +2193,15 @@ impl<T> Extend<(HeaderName, T)> for HeaderMap<T> {
         // will only resize twice in the worst case.
         let iter = iter.into_iter();
 
-        let reserve = if self.is_empty() {
+        let hint = if self.is_empty() {
             iter.size_hint().0
         } else {
             (iter.size_hint().0 + 1) / 2
         };
+
+        // Clamp the hint so an over-estimate cannot overflow `reserve`.
+        let max_reserve = usable_capacity(MAX_SIZE).saturating_sub(self.entries.len());
+        let reserve = hint.min(max_reserve);
 
         self.reserve(reserve);
 

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -56,6 +56,23 @@ fn with_capacity_overflow() {
 }
 
 #[test]
+fn extend_size_hint_above_capacity() {
+    // A `HeaderMap` may hold more values than the table can index when many
+    // values are appended under one name, so an exact size hint can exceed the
+    // largest `reserve` request. Extending must not panic in that case.
+    let name = HeaderName::from_static("h");
+    let value = HeaderValue::from_static("0");
+    let pairs: Vec<(HeaderName, HeaderValue)> =
+        std::iter::repeat_with(|| (name.clone(), value.clone()))
+            .take(24_577)
+            .collect();
+
+    let map = HeaderMap::from_iter(pairs);
+    assert_eq!(map.len(), 24_577);
+    assert_eq!(map.keys_len(), 1);
+}
+
+#[test]
 #[should_panic]
 fn reserve_overflow() {
     // See https://github.com/hyperium/http/issues/352


### PR DESCRIPTION
Both `Extend` impls pass the iterator's size hint straight to `reserve`, but that hint can exceed the number of names the table is able to index (e.g. when the iterator yields many appended values for one name), causing a `MaxSizeReached` panic for input that the map can actually hold. This clamps the reservation to the largest value `reserve` will accept.

Closes #604