### PR TITLE
feat(method): impl PartialOrd + Ord

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -187,6 +187,20 @@ impl AsRef<str> for Method {
     }
 }
 
+impl Ord for Method {
+    #[inline]
+    fn cmp(&self, other: &Method) -> std::cmp::Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl PartialOrd for Method {
+    #[inline]
+    fn partial_cmp(&self, other: &Method) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl PartialEq<&Method> for Method {
     #[inline]
     fn eq(&self, other: &&Method) -> bool {


### PR DESCRIPTION
This allows Method (and anyone who contains it) to be used as B-tree keys.