### PR TITLE
fix: reject DEL character

### DIFF
--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -447,7 +447,7 @@ const fn scan_path_and_query(bytes: &[u8]) -> Result<Scanned, ErrorKind> {
             0x7E => {}
 
             // potentially utf8, might not, should check
-            0x7F..=0xFF => {
+            0x80..=0xFF => {
                 is_maybe_not_utf8 = true;
             }
 
@@ -484,7 +484,7 @@ const fn scan_path_and_query(bytes: &[u8]) -> Result<Scanned, ErrorKind> {
                 0x3D |
                 0x3F..=0x7E => {}
 
-                0x7F..=0xFF => {
+                0x80..=0xFF => {
                     is_maybe_not_utf8 = true;
                 }
 
@@ -637,6 +637,16 @@ mod tests {
     #[test]
     fn requires_starting_with_slash() {
         PathAndQuery::try_from("sneaky").expect_err("reject missing slash");
+    }
+
+    #[test]
+    fn rejects_del_in_path() {
+        PathAndQuery::try_from(&[b'/', 0x7F][..]).expect_err("reject DEL");
+    }
+
+    #[test]
+    fn rejects_del_in_query() {
+        PathAndQuery::try_from(&[b'/', b'a', b'?', 0x7F][..]).expect_err("reject DEL");
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does
This PR addresses the bug where the `http` crate accidentally allows the raw ASCII `DEL` control character (`0x7F`) in URI paths and queries. It resurrects and updates the changes originally proposed in the dead PR #821.

## Context
PR #715 intentionally allowed raw UTF-8 to support all those web crawlers and browsers (like Google AppEngine, Safari, etc.) that send unescaped international characters. However, because the parser was checking the range `0x7F..=0xFF`, the ASCII `DEL` control character (`0x7F`) accidentally snuck through! 

But are those legitimate bots or browsers actually need to send a raw `DEL` character? Leaving it open may cause parser differential/security issues downstream if a proxy handles a raw `DEL` differently than this crate does. 

## The Solution
By tweaking the range from `0x7F..=0xFF` to `0x80..=0xFF`, we perfectly protect all the intended UTF-8 traffic while safely dropping and rejecting `DEL` as an invalid control character.

I have also included the regression tests (`rejects_del_in_path` and `rejects_del_in_query`) to make sure this stays fixed.

## A Quick Question for Maintainers
Is allowing `0x7F` here actually intentional for some edge case I might be missing? I want to make sure I'm not talking nonsense or overlooking a specific design choice from #715. If this behavior is completely intentional, please let me know and I am more than happy to close this PR.

Closes #820