### PR TITLE
fix(uri): allow STAR paths with scheme/auth

### DIFF
--- a/src/uri/builder.rs
+++ b/src/uri/builder.rs
@@ -208,4 +208,18 @@ mod tests {
         let uri = Builder::from(original_uri.clone()).build().unwrap();
         assert_eq!(original_uri, uri);
     }
+
+    #[test]
+    fn build_star_for_http2() {
+        let uri = Builder::new()
+            .scheme("https")
+            .authority("example.com")
+            .path_and_query("*")
+            .build()
+            .unwrap();
+
+        assert_eq!(uri.scheme(), Some(&Scheme::HTTPS));
+        assert_eq!(uri.host(), Some("example.com"));
+        assert_eq!(uri.path(), "*");
+    }
 }

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -416,6 +416,14 @@ const fn scan_path_and_query(bytes: &[u8]) -> Result<Scanned, ErrorKind> {
         return Err(ErrorKind::Empty);
     }
 
+    if bytes.len() == 1 && bytes[0] == b'*' {
+        return Ok(Scanned {
+            query,
+            fragment,
+            is_maybe_not_utf8: false,
+        });
+    }
+
     if !matches!(bytes[0], b'/' | b'?' | b'#') {
         return Err(ErrorKind::PathDoesNotStartWithSlash);
     }


### PR DESCRIPTION
When making `OPTIONS *` requests in HTTP/2, the scheme and authority must still be set, and the `:path` must be `*`. The fix in 1.4.1 prevented this combination (plain `*` still worked, but HTTP/2 needs more).