### PR TITLE
feat(uri): derive equality for URI errors

### DIFF
--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -118,11 +118,11 @@ pub struct Parts {
 }
 
 /// An error resulting from a failed attempt to construct a URI.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InvalidUri(ErrorKind);
 
 /// An error resulting from a failed attempt to construct a URI.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InvalidUriParts(InvalidUri);
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/uri/tests.rs
+++ b/src/uri/tests.rs
@@ -441,6 +441,28 @@ fn test_uri_parse_error() {
 }
 
 #[test]
+fn test_invalid_uri_errors_are_comparable() {
+    fn assert_eq_impl<T: Eq>() {}
+
+    fn invalid_uri_parts() -> super::InvalidUriParts {
+        let mut parts = super::Parts::default();
+        parts.authority = Some("example.com".parse().unwrap());
+        parts.path_and_query = Some("/".parse().unwrap());
+
+        Uri::from_parts(parts).unwrap_err()
+    }
+
+    assert_eq_impl::<InvalidUri>();
+    assert_eq_impl::<super::InvalidUriParts>();
+
+    assert_eq!(
+        "http://[::1".parse::<Uri>().unwrap_err(),
+        "http://[::1".parse::<Uri>().unwrap_err(),
+    );
+    assert_eq!(invalid_uri_parts(), invalid_uri_parts());
+}
+
+#[test]
 fn test_max_uri_len() {
     let mut uri = vec![];
     uri.extend(b"http://localhost/");


### PR DESCRIPTION
## Motivation

I opened [#849](https://github.com/hyperium/http/issues/849) as the durable place for the API tradeoff. This PR is a small concrete version of the change so maintainers can evaluate the actual patch shape.

I have a library error type that wraps `http::uri::InvalidUri`. I would like that error type to derive `PartialEq` and `Eq` for straightforward unit tests, but `InvalidUri` currently prevents that.

## Change

This derives `PartialEq` and `Eq` for `InvalidUri` and `InvalidUriParts`. `ErrorKind` remains private.

The test checks that both public error types implement `Eq` and that repeated `InvalidUri` / `InvalidUriParts` failures can be compared directly.

## Compatibility

I realize this is still a public contract. Prior discussions such as [#128](https://github.com/hyperium/http/pull/128) and [#204](https://github.com/hyperium/http/pull/204) were cautious about trait impls on error types because they can constrain future internals.

My take is that `PartialEq`/`Eq` is a smaller commitment than `Clone`: it does not expose `ErrorKind`, and equality can remain a coarse comparison over the existing broad URI error category. That said, users could observe whether two `InvalidUri` values compare equal, so I am opening this as a draft PR to get maintainer feedback on that tradeoff.

Refs #849.

## Validation

```text
cargo fmt --check
cargo test
```
