### PR TITLE
feat(method): add cacheability helper

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -166,6 +166,19 @@ impl Method {
         }
     }
 
+    /// Whether a response to the method is defined as cacheable.
+    ///
+    /// This only indicates whether the method's semantics allow caching. A
+    /// response might still not be storable or reusable by a cache depending on
+    /// its status code, headers, and method-specific conditions.
+    ///
+    /// See [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.3)
+    /// and [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008#section-2.7)
+    /// for more words.
+    pub fn is_cacheable(&self) -> bool {
+        matches!(self.0, Get | Head | Post | Query)
+    }
+
     /// Return a &str representation of the HTTP method
     #[inline]
     pub fn as_str(&self) -> &str {
@@ -477,6 +490,22 @@ mod test {
         assert!(!Method::POST.is_idempotent());
         assert!(!Method::CONNECT.is_idempotent());
         assert!(!Method::PATCH.is_idempotent());
+    }
+
+    #[test]
+    fn test_is_cacheable() {
+        assert!(Method::GET.is_cacheable());
+        assert!(Method::HEAD.is_cacheable());
+        assert!(Method::POST.is_cacheable());
+        assert!(Method::QUERY.is_cacheable());
+
+        assert!(!Method::PUT.is_cacheable());
+        assert!(!Method::DELETE.is_cacheable());
+        assert!(!Method::CONNECT.is_cacheable());
+        assert!(!Method::OPTIONS.is_cacheable());
+        assert!(!Method::PATCH.is_cacheable());
+        assert!(!Method::TRACE.is_cacheable());
+        assert!(!Method::from_str("WOW").unwrap().is_cacheable());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  Add `Method::is_cacheable()` as a convenience helper for checking whether
  a method's response is defined as cacheable by method semantics.

  The helper returns `true` for:

  - `GET`
  - `HEAD`
  - `POST`
  - `QUERY`

  It returns `false` for methods whose general method semantics are not
  cacheable here, as well as extension methods whose cache semantics are
  unknown.

  ## Motivation

  `Method` already exposes `is_safe()` and `is_idempotent()`, but callers
  that need to reason about HTTP caching currently need to duplicate method
  checks themselves.

  This adds a small helper for the method-level part of that decision.

  The method intentionally only indicates whether caching is allowed by the
  method semantics. A response may still be non-cacheable depending on its
  status code, cache headers, and method-specific requirements.

  ## Notes

  `POST` is included because RFC 9110 defines cache semantics for POST
  responses, although actual caching still requires the response to satisfy
  the relevant HTTP caching rules.

  `QUERY` is included based on RFC 10008, which defines caching semantics
  for QUERY responses.

  `PATCH` is not included in this helper to keep the result aligned with
  the general cacheable method set used here.

  ## References

  - RFC 9110, Section 9.2.3: https://www.rfc-editor.org/rfc/rfc9110#section-9.2.3
  - RFC 10008, Section 2.7: https://www.rfc-editor.org/rfc/rfc10008#section-2.7

  ## Testing

  - `cargo fmt --check`
  - `cargo test test_is_cacheable`
  - `cargo test`