### PR TITLE
fix(header): reject values with bytes > 127u8

### DIFF
--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -561,7 +561,7 @@ const fn is_visible_ascii(b: u8) -> bool {
 
 #[inline]
 fn is_valid(b: u8) -> bool {
-    b >= 32 && b != 127 || b == b'\t'
+    (32..=127).contains(&b) || b == b'\t'
 }
 
 impl fmt::Debug for InvalidHeaderValue {


### PR DESCRIPTION
The documentation currently states:

> If the argument contains invalid header value characters, an error is returned. Only visible ASCII characters (32-127) are permitted. Use from_bytes to create a HeaderValue that includes opaque octets (128-255).

This change limits the upper bound on bytes to 127, making use of RangeInclusive, stable since Rust 1.35.0.

It also allows the tab char (as RFC conformant linear white space). The docs should be amended to mention this as well. I considered it out of scope for this PR.