### PR TITLE
test(header): fix trait bounds in test_bounds to Send + Sync (#783)

### DIFF
--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -4026,7 +4026,7 @@ mod as_header_name {
 
 #[test]
 fn test_bounds() {
-    fn check_bounds<T: Send + Send>() {}
+    fn check_bounds<T: Send + Sync>() {}
 
     check_bounds::<HeaderMap<()>>();
     check_bounds::<Iter<'static, ()>>();


### PR DESCRIPTION
## Summary

Fixes #783.

In `src/header/map.rs`, `test_bounds()` defines a nested helper:
```rust
fn check_bounds<T: Send + Send>() {}
```
The bound repeated `Send` instead of testing both `Send` and `Sync`.

This PR changes the trait bounds to `T: Send + Sync` so that `HeaderMap` and its associated iterators and entries (`Iter`, `IterMut`, `Keys`, `Values`, `ValuesMut`, `Drain`, `GetAll`, `Entry`, `VacantEntry`, `OccupiedEntry`, `ValueIter`, `ValueIterMut`, `ValueDrain`) are verified to implement both `Send` and `Sync`.

## Verification

- `cargo test header::map::test_bounds`: PASS
- `cargo test`: 228 tests passed cleanly
- `cargo fmt --all --check`: clean