### PR TITLE
feat(request,response): add borrowed parts accessors

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -453,6 +453,27 @@ impl<T> Request<T> {
         Request { head: parts, body }
     }
 
+    /// Returns a reference to the request's component parts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    /// let request = Request::builder()
+    ///     .method(Method::POST)
+    ///     .uri("/hello")
+    ///     .body(())
+    ///     .unwrap();
+    ///
+    /// let parts = request.parts();
+    /// assert_eq!(parts.method, Method::POST);
+    /// assert_eq!(parts.uri, "/hello");
+    /// ```
+    #[inline]
+    pub fn parts(&self) -> &Parts {
+        &self.head
+    }
+
     /// Returns a reference to the associated HTTP method.
     ///
     /// # Examples
@@ -1059,6 +1080,20 @@ impl Default for Builder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn it_can_borrow_parts() {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/hello")
+            .body("body")
+            .unwrap();
+
+        let parts = request.parts();
+        assert_eq!(parts.method, Method::POST);
+        assert_eq!(parts.uri, "/hello");
+        assert_eq!(request.body(), &"body");
+    }
 
     #[test]
     fn it_can_map_a_body_from_one_type_to_another() {

--- a/src/response.rs
+++ b/src/response.rs
@@ -271,6 +271,25 @@ impl<T> Response<T> {
         Response { head: parts, body }
     }
 
+    /// Returns a reference to the response's component parts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use http::*;
+    /// let response = Response::builder()
+    ///     .status(StatusCode::CREATED)
+    ///     .body(())
+    ///     .unwrap();
+    ///
+    /// let parts = response.parts();
+    /// assert_eq!(parts.status, StatusCode::CREATED);
+    /// ```
+    #[inline]
+    pub fn parts(&self) -> &Parts {
+        &self.head
+    }
+
     /// Returns the `StatusCode`.
     ///
     /// # Examples
@@ -768,6 +787,18 @@ impl Default for Builder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn it_can_borrow_parts() {
+        let response = Response::builder()
+            .status(StatusCode::CREATED)
+            .body("body")
+            .unwrap();
+
+        let parts = response.parts();
+        assert_eq!(parts.status, StatusCode::CREATED);
+        assert_eq!(response.body(), &"body");
+    }
 
     #[test]
     fn it_can_map_a_body_from_one_type_to_another() {


### PR DESCRIPTION
- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)

This adds a smaller helper to expose `&Parts`. Today you can only do `into_parts()` but requires ownership.

My main motivation is I have various helpers that require `&Parts`. Today this is called by something that owns req and does into_parts(); but now I have a `&Request` so I cannot use it. Fixing this requires duplicating the same function for `Request` and `Parts`